### PR TITLE
Add latest tag to Docker image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
 
       - name: Build and push
         id: push


### PR DESCRIPTION
## Summary
- Configure docker/metadata-action to tag images with `latest` in addition to semver tags
- This allows users to pull `ghcr.io/interlynk-io/lynk-mcp:latest`

## Test plan
- [ ] Merge and publish a new release
- [ ] Verify `latest` tag is created on ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)