### PR TITLE
Fix MCP connection timeout for new tokens

### DIFF
--- a/cmd/lynk-mcp/main.go
+++ b/cmd/lynk-mcp/main.go
@@ -17,10 +17,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/interlynk-io/lynk-mcp/internal/api"
 	"github.com/interlynk-io/lynk-mcp/internal/config"
 	"github.com/interlynk-io/lynk-mcp/internal/mcp"
+	"github.com/interlynk-io/lynk-mcp/internal/retry"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"sigs.k8s.io/release-utils/version"
@@ -134,9 +136,20 @@ func runVerify(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(cfg.API.Endpoint, token, cfg.API.Timeout)
 
-	org, err := client.GetOrganization(cmd.Context())
+	var org *api.Organization
+	start := time.Now()
+
+	err = retry.Do(cmd.Context(), retry.DefaultVerifyConfig(), func() error {
+		var getErr error
+		org, getErr = client.GetOrganization(cmd.Context())
+		return getErr
+	}, nil, func(attempt int, retryErr error, delay time.Duration) {
+		elapsed := time.Since(start).Truncate(time.Second)
+		fmt.Printf("  Attempt %d failed (%s elapsed): %v\n", attempt, elapsed, retryErr)
+		fmt.Printf("  Token may still be propagating. Retrying in %s...\n", delay.Truncate(time.Second))
+	})
 	if err != nil {
-		return fmt.Errorf("failed to connect: %w", err)
+		return fmt.Errorf("failed to connect after %s: %w", time.Since(start).Truncate(time.Second), err)
 	}
 
 	fmt.Println()

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -18,17 +18,32 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
+
+	"github.com/interlynk-io/lynk-mcp/internal/retry"
 )
+
+// HTTPError represents an HTTP error response with a status code.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %s", e.StatusCode, e.Body)
+}
 
 // Client is a GraphQL client for the Lynk API
 type Client struct {
-	endpoint   string
-	token      string
-	httpClient *http.Client
+	endpoint    string
+	token       string
+	httpClient  *http.Client
+	retryConfig retry.Config
 }
 
 // NewClient creates a new GraphQL client
@@ -39,6 +54,7 @@ func NewClient(endpoint, token string, timeout time.Duration) *Client {
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
+		retryConfig: retry.DefaultTransientConfig(),
 	}
 }
 
@@ -68,8 +84,31 @@ type ErrorLocation struct {
 	Column int `json:"column"`
 }
 
-// Execute executes a GraphQL query and returns the response
+// isTransientError returns true for errors that are worth retrying:
+// 5xx server errors, 429 rate limiting, and network-level errors.
+func isTransientError(err error) bool {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 || httpErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	return false
+}
+
+// Execute executes a GraphQL query with automatic retry for transient errors.
 func (c *Client) Execute(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
+	return retry.Do(ctx, c.retryConfig, func() error {
+		return c.executeOnce(ctx, query, variables, result)
+	}, isTransientError, nil)
+}
+
+// executeOnce performs a single GraphQL request.
+func (c *Client) executeOnce(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
 	req := Request{
 		Query:     query,
 		Variables: variables,
@@ -101,7 +140,7 @@ func (c *Client) Execute(ctx context.Context, query string, variables map[string
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(respBody))
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	var graphQLResp Response

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+)
+
+// Config controls retry behavior.
+type Config struct {
+	MaxRetries   int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	BackoffFactor float64
+}
+
+// DefaultTransientConfig returns a config for retrying transient errors
+// at the GraphQL client level (3 retries, 1s initial, 10s max, 2x backoff).
+func DefaultTransientConfig() Config {
+	return Config{
+		MaxRetries:    3,
+		InitialDelay:  1 * time.Second,
+		MaxDelay:      10 * time.Second,
+		BackoffFactor: 2.0,
+	}
+}
+
+// DefaultVerifyConfig returns a config for the verify command retry loop
+// (24 retries, 10s initial, 15s max, 1.5x backoff, ~6 min total).
+func DefaultVerifyConfig() Config {
+	return Config{
+		MaxRetries:    24,
+		InitialDelay:  10 * time.Second,
+		MaxDelay:      15 * time.Second,
+		BackoffFactor: 1.5,
+	}
+}
+
+// Do executes fn with retries according to cfg.
+//
+// shouldRetry decides whether a given error is retryable. If nil, all errors
+// are retried.
+//
+// onRetry is called before each retry sleep with the attempt number (1-based),
+// the error from the last attempt, and the delay before the next attempt.
+// It may be nil.
+func Do(ctx context.Context, cfg Config, fn func() error, shouldRetry func(error) bool, onRetry func(attempt int, err error, delay time.Duration)) error {
+	var lastErr error
+
+	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+
+		if shouldRetry != nil && !shouldRetry(lastErr) {
+			return lastErr
+		}
+
+		if attempt == cfg.MaxRetries {
+			break
+		}
+
+		delay := time.Duration(float64(cfg.InitialDelay) * math.Pow(cfg.BackoffFactor, float64(attempt)))
+		if delay > cfg.MaxDelay {
+			delay = cfg.MaxDelay
+		}
+
+		if onRetry != nil {
+			onRetry(attempt+1, lastErr, delay)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w (last error: %v)", ctx.Err(), lastErr)
+		case <-time.After(delay):
+		}
+	}
+
+	return fmt.Errorf("after %d attempts: %w", cfg.MaxRetries+1, lastErr)
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDo_SuccessOnFirstTry(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{
+		MaxRetries:    3,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}, func() error {
+		calls++
+		return nil
+	}, nil, nil)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDo_SuccessAfterRetries(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{
+		MaxRetries:    5,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient error")
+		}
+		return nil
+	}, nil, nil)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_AllRetriesExhausted(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{
+		MaxRetries:    3,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}, func() error {
+		calls++
+		return errors.New("persistent error")
+	}, nil, nil)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// 1 initial + 3 retries = 4
+	if calls != 4 {
+		t.Fatalf("expected 4 calls, got %d", calls)
+	}
+}
+
+func TestDo_NonRetryableError(t *testing.T) {
+	authErr := errors.New("401 unauthorized")
+	calls := 0
+
+	err := Do(context.Background(), Config{
+		MaxRetries:    5,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}, func() error {
+		calls++
+		return authErr
+	}, func(err error) bool {
+		return false // nothing is retryable
+	}, nil)
+
+	if !errors.Is(err, authErr) {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call (no retry), got %d", calls)
+	}
+}
+
+func TestDo_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	err := Do(ctx, Config{
+		MaxRetries:    100,
+		InitialDelay:  50 * time.Millisecond,
+		MaxDelay:      50 * time.Millisecond,
+		BackoffFactor: 1.0,
+	}, func() error {
+		calls++
+		return errors.New("keep failing")
+	}, nil, nil)
+
+	if err == nil {
+		t.Fatal("expected error from context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestDo_OnRetryCallback(t *testing.T) {
+	var retryAttempts []int
+	var retryErrors []error
+
+	targetErr := errors.New("fail")
+
+	err := Do(context.Background(), Config{
+		MaxRetries:    3,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      10 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}, func() error {
+		return targetErr
+	}, nil, func(attempt int, err error, delay time.Duration) {
+		retryAttempts = append(retryAttempts, attempt)
+		retryErrors = append(retryErrors, err)
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(retryAttempts) != 3 {
+		t.Fatalf("expected 3 onRetry calls, got %d", len(retryAttempts))
+	}
+	for i, a := range retryAttempts {
+		if a != i+1 {
+			t.Fatalf("expected attempt %d, got %d", i+1, a)
+		}
+	}
+	for _, e := range retryErrors {
+		if !errors.Is(e, targetErr) {
+			t.Fatalf("expected target error in callback, got %v", e)
+		}
+	}
+}
+
+func TestDo_BackoffCappedAtMaxDelay(t *testing.T) {
+	var delays []time.Duration
+
+	_ = Do(context.Background(), Config{
+		MaxRetries:    3,
+		InitialDelay:  10 * time.Millisecond,
+		MaxDelay:      15 * time.Millisecond,
+		BackoffFactor: 10.0,
+	}, func() error {
+		return errors.New("fail")
+	}, nil, func(attempt int, err error, delay time.Duration) {
+		delays = append(delays, delay)
+	})
+
+	for i, d := range delays {
+		if d > 15*time.Millisecond {
+			t.Fatalf("delay %d exceeded max: %v", i, d)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a reusable `internal/retry` package with configurable exponential backoff, context-aware cancellation, and optional `shouldRetry`/`onRetry` callbacks
- Adds **Layer 1** retry in the GraphQL client for transient errors (5xx, 429, network timeouts) — 3 retries, 1s initial delay, 2x backoff
- Adds **Layer 2** retry in the `verify` command for all errors including auth during token propagation — 24 retries, 10s initial delay, ~6 minutes total coverage
- Introduces `HTTPError` struct in the GraphQL client for structured status code handling
- Prints progress messages during verify retries (attempt number, elapsed time, error, propagation hint)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/retry/...` — 7 tests pass (first-try success, retry success, exhaustion, non-retryable short-circuit, context cancellation, onRetry callback, backoff capping)
- [x] `go vet ./...` passes
- [ ] Manual: `lynk-mcp verify` with valid token succeeds on first attempt (no retry output)
- [ ] Manual: `lynk-mcp verify` with new token shows retry progress and eventually succeeds

Closes #15