### PR TITLE
Support service test tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,4 +34,4 @@ Recent commit history uses short, imperative summaries with optional PR numbers,
 
 ## Security & Configuration Tips
 
-Do not commit API tokens or local config. Runtime config is stored in `~/.lynk-mcp/config.yaml`, and tokens should come from the system keychain or `LYNK_API_TOKEN`. Use `lynk_test_*` or staging tokens for development.
+Do not commit API tokens or local config. Runtime config is stored in `~/.lynk-mcp/config.yaml`, and tokens should come from the system keychain or `LYNK_API_TOKEN`. Use `lynk_test_*`, `lynk_service_test_*`, or staging tokens for development.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ lynk-mcp configure
 
 This prompts for:
 1. API Endpoint (defaults to https://api.interlynk.io/lynkapi)
-2. API Token (your Lynk API key: `lynk_live_*`, `lynk_staging_*`, or `lynk_test_*`)
+2. API Token (your Lynk API key: `lynk_live_*`, `lynk_staging_*`, `lynk_test_*`, or `lynk_service_test_*`)
 
 The token is stored securely in your system keychain.
 

--- a/cmd/lynk-mcp/main.go
+++ b/cmd/lynk-mcp/main.go
@@ -99,7 +99,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 
 	// Validate token format
 	if !config.ValidateTokenFormat(token) {
-		return fmt.Errorf("invalid token format: must start with lynk_live_, lynk_staging_, or lynk_test_")
+		return fmt.Errorf("invalid token format: must start with one of: %s", config.ValidTokenPrefixesDescription())
 	}
 
 	// Store token in keyring

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -27,15 +27,21 @@ const (
 	tokenKey    = "api-token"
 )
 
+var validTokenPrefixes = []string{
+	"lynk_live_",
+	"lynk_staging_",
+	"lynk_test_",
+	"lynk_service_test_",
+}
+
+// ValidTokenPrefixesDescription returns the accepted token prefixes for errors/help text.
+func ValidTokenPrefixesDescription() string {
+	return strings.Join(validTokenPrefixes, ", ")
+}
+
 // ValidateTokenFormat checks if the token has a valid format
 func ValidateTokenFormat(token string) bool {
-	validPrefixes := []string{
-		"lynk_live_",
-		"lynk_staging_",
-		"lynk_test_",
-	}
-
-	for _, prefix := range validPrefixes {
+	for _, prefix := range validTokenPrefixes {
 		if strings.HasPrefix(token, prefix) {
 			return true
 		}
@@ -72,7 +78,7 @@ func GetToken() (string, error) {
 	// Check environment variable first (useful for Docker/CI environments)
 	if token := os.Getenv(EnvTokenKey); token != "" {
 		if !ValidateTokenFormat(token) {
-			return "", fmt.Errorf("invalid token format in %s: must start with lynk_live_, lynk_staging_, or lynk_test_", EnvTokenKey)
+			return "", fmt.Errorf("invalid token format in %s: must start with one of: %s", EnvTokenKey, ValidTokenPrefixesDescription())
 		}
 		return token, nil
 	}

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTokenFormat_AcceptsKnownPrefixes(t *testing.T) {
+	tokens := []string{
+		"lynk_live_abc",
+		"lynk_staging_abc",
+		"lynk_test_abc",
+		"lynk_service_test_abc",
+	}
+
+	for _, token := range tokens {
+		if !ValidateTokenFormat(token) {
+			t.Fatalf("expected token %q to be valid", token)
+		}
+	}
+}
+
+func TestValidateTokenFormat_RejectsUnknownPrefixes(t *testing.T) {
+	tokens := []string{
+		"",
+		"lynk_service_live_abc",
+		"lynk_service_staging_abc",
+		"other_test_abc",
+	}
+
+	for _, token := range tokens {
+		if ValidateTokenFormat(token) {
+			t.Fatalf("expected token %q to be invalid", token)
+		}
+	}
+}
+
+func TestValidTokenPrefixesDescription_IncludesServiceTestPrefix(t *testing.T) {
+	if !strings.Contains(ValidTokenPrefixesDescription(), "lynk_service_test_") {
+		t.Fatalf("expected service test prefix in description")
+	}
+}


### PR DESCRIPTION
## Summary
- accept lynk_service_test_ tokens in token validation
- centralize accepted token prefix help text for configure/env errors
- add focused config tests and update README/AGENTS docs

## Validation
- make test