### PR TITLE
Fix get_product environment pagination

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -21,9 +21,13 @@ import (
 	"github.com/interlynk-io/lynk-mcp/internal/graphql"
 )
 
+type graphQLExecutor interface {
+	Execute(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error
+}
+
 // Client provides high-level operations for the Lynk API
 type Client struct {
-	gql *graphql.Client
+	gql graphQLExecutor
 }
 
 // NewClient creates a new API client

--- a/internal/api/products.go
+++ b/internal/api/products.go
@@ -16,10 +16,13 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/interlynk-io/lynk-mcp/internal/graphql"
 )
+
+const getProductEnvironmentsPageSize = 100
 
 // Product represents a product (formerly project group)
 type Product struct {
@@ -123,57 +126,85 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 
 // GetProduct fetches a single product by ID
 func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
-	vars := map[string]interface{}{
-		"id": id,
-	}
+	var product *Product
+	var environments []Environment
+	var after string
 
-	var result struct {
-		ProjectGroup struct {
-			ID             string    `json:"id"`
-			Name           string    `json:"name"`
-			Description    string    `json:"description"`
-			Enabled        bool      `json:"enabled"`
-			OrganizationID string    `json:"organizationId"`
-			UpdatedAt      time.Time `json:"updatedAt"`
-			SbomsCount     int       `json:"sbomsCount"`
-			Projects       []struct {
-				ID          string    `json:"id"`
-				Name        string    `json:"name"`
-				Description string    `json:"description"`
-				Enabled     bool      `json:"enabled"`
-				UpdatedAt   time.Time `json:"updatedAt"`
-				SbomsCount  int       `json:"sbomsCount"`
-			} `json:"projects"`
-		} `json:"projectGroup"`
-	}
+	for {
+		vars := map[string]interface{}{
+			"id":            id,
+			"projectsFirst": getProductEnvironmentsPageSize,
+		}
+		if after != "" {
+			vars["projectsAfter"] = after
+		}
 
-	if err := c.gql.Execute(ctx, graphql.ProjectGroupQuery, vars, &result); err != nil {
-		return nil, err
-	}
+		var result struct {
+			ProjectGroup struct {
+				ID             string    `json:"id"`
+				Name           string    `json:"name"`
+				Description    string    `json:"description"`
+				Enabled        bool      `json:"enabled"`
+				OrganizationID string    `json:"organizationId"`
+				UpdatedAt      time.Time `json:"updatedAt"`
+				SbomsCount     int       `json:"sbomsCount"`
+				Projects       struct {
+					Nodes []struct {
+						ID          string    `json:"id"`
+						Name        string    `json:"name"`
+						Description string    `json:"description"`
+						Enabled     bool      `json:"enabled"`
+						UpdatedAt   time.Time `json:"updatedAt"`
+						SbomsCount  int       `json:"sbomsCount"`
+					} `json:"nodes"`
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+				} `json:"projects"`
+			} `json:"projectGroup"`
+		}
 
-	environments := make([]Environment, len(result.ProjectGroup.Projects))
-	for i, p := range result.ProjectGroup.Projects {
-		environments[i] = Environment{
-			ID:            p.ID,
-			Name:          p.Name,
-			Description:   p.Description,
-			Enabled:       p.Enabled,
-			UpdatedAt:     p.UpdatedAt,
-			VersionsCount: p.SbomsCount,
-			ProductID:     result.ProjectGroup.ID,
+		if err := c.gql.Execute(ctx, graphql.ProjectGroupQuery, vars, &result); err != nil {
+			return nil, err
+		}
+
+		if product == nil {
+			product = &Product{
+				ID:             result.ProjectGroup.ID,
+				Name:           result.ProjectGroup.Name,
+				Description:    result.ProjectGroup.Description,
+				Enabled:        result.ProjectGroup.Enabled,
+				OrganizationID: result.ProjectGroup.OrganizationID,
+				UpdatedAt:      result.ProjectGroup.UpdatedAt,
+				VersionsCount:  result.ProjectGroup.SbomsCount,
+			}
+		}
+
+		for _, p := range result.ProjectGroup.Projects.Nodes {
+			environments = append(environments, Environment{
+				ID:            p.ID,
+				Name:          p.Name,
+				Description:   p.Description,
+				Enabled:       p.Enabled,
+				UpdatedAt:     p.UpdatedAt,
+				VersionsCount: p.SbomsCount,
+				ProductID:     result.ProjectGroup.ID,
+			})
+		}
+
+		if !result.ProjectGroup.Projects.PageInfo.HasNextPage {
+			break
+		}
+
+		after = result.ProjectGroup.Projects.PageInfo.EndCursor
+		if after == "" {
+			return nil, fmt.Errorf("project group projects pageInfo has next page without end cursor")
 		}
 	}
 
-	return &Product{
-		ID:             result.ProjectGroup.ID,
-		Name:           result.ProjectGroup.Name,
-		Description:    result.ProjectGroup.Description,
-		Enabled:        result.ProjectGroup.Enabled,
-		OrganizationID: result.ProjectGroup.OrganizationID,
-		UpdatedAt:      result.ProjectGroup.UpdatedAt,
-		VersionsCount:  result.ProjectGroup.SbomsCount,
-		Environments:   environments,
-	}, nil
+	product.Environments = environments
+	return product, nil
 }
 
 // GetEnvironment fetches a single environment by ID

--- a/internal/api/products_test.go
+++ b/internal/api/products_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fakeGraphQLExecutor struct {
+	requests []map[string]interface{}
+	pages    []string
+}
+
+func (f *fakeGraphQLExecutor) Execute(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
+	f.requests = append(f.requests, variables)
+	return json.Unmarshal([]byte(f.pages[len(f.requests)-1]), result)
+}
+
+func TestGetProduct_PaginatesEnvironments(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"projectGroup": {
+					"id": "product-1",
+					"name": "Product 1",
+					"description": "",
+					"enabled": true,
+					"organizationId": "org-1",
+					"updatedAt": "2026-04-16T23:00:09Z",
+					"sbomsCount": 2,
+					"projects": {
+						"nodes": [
+							{
+								"id": "env-1",
+								"name": "default",
+								"description": "default environment",
+								"enabled": true,
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 1
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": true,
+							"endCursor": "cursor-1"
+						}
+					}
+				}
+			}`,
+			`{
+				"projectGroup": {
+					"id": "product-1",
+					"name": "Product 1",
+					"description": "",
+					"enabled": true,
+					"organizationId": "org-1",
+					"updatedAt": "2026-04-16T23:00:09Z",
+					"sbomsCount": 2,
+					"projects": {
+						"nodes": [
+							{
+								"id": "env-2",
+								"name": "production",
+								"description": "production environment",
+								"enabled": true,
+								"updatedAt": "2026-04-16T23:00:10Z",
+								"sbomsCount": 1
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+
+	client := &Client{gql: gql}
+	product, err := client.GetProduct(context.Background(), "product-1")
+	if err != nil {
+		t.Fatalf("GetProduct returned error: %v", err)
+	}
+
+	if len(product.Environments) != 2 {
+		t.Fatalf("expected 2 environments, got %d", len(product.Environments))
+	}
+	if product.Environments[0].ID != "env-1" || product.Environments[1].ID != "env-2" {
+		t.Fatalf("unexpected environments: %#v", product.Environments)
+	}
+	if len(gql.requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gql.requests))
+	}
+	if gql.requests[0]["projectsAfter"] != nil {
+		t.Fatalf("first request should not include projectsAfter, got %#v", gql.requests[0]["projectsAfter"])
+	}
+	if gql.requests[1]["projectsAfter"] != "cursor-1" {
+		t.Fatalf("second request projectsAfter = %#v, want cursor-1", gql.requests[1]["projectsAfter"])
+	}
+}

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -66,7 +66,7 @@ const (
 
 	// ProjectGroupQuery fetches a single project group by ID
 	ProjectGroupQuery = `
-		query GetProjectGroup($id: Uuid!) {
+		query GetProjectGroup($id: Uuid!, $projectsFirst: Int, $projectsAfter: String) {
 			projectGroup(id: $id) {
 				id
 				name
@@ -75,13 +75,19 @@ const (
 				organizationId
 				updatedAt
 				sbomsCount
-				projects {
-					id
-					name
-					description
-					enabled
-					updatedAt
-					sbomsCount
+				projects(first: $projectsFirst, after: $projectsAfter) {
+					nodes {
+						id
+						name
+						description
+						enabled
+						updatedAt
+						sbomsCount
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
 				}
 			}
 		}

--- a/internal/graphql/queries_test.go
+++ b/internal/graphql/queries_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphql
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestProjectGroupQuery_ProjectsUsesConnectionNodes(t *testing.T) {
+	if !regexp.MustCompile(`projects\s*\([^)]*\)\s*\{\s*nodes\s*\{`).MatchString(ProjectGroupQuery) {
+		t.Fatal("ProjectGroupQuery must select projects through the ProjectConnection nodes field")
+	}
+}


### PR DESCRIPTION
## Summary
- paginate projectGroup.projects in get_product using first/after and pageInfo
- map environments from connection nodes across all pages
- add focused tests for query shape and multi-page environment retrieval

## Validation
- env GOCACHE=/private/tmp/lynk-mcp-gocache go test ./...