### PR TITLE
Add SBOM Doctor results tool

### DIFF
--- a/internal/api/doctor.go
+++ b/internal/api/doctor.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+
+	"github.com/interlynk-io/lynk-mcp/internal/graphql"
+)
+
+// DoctorFinding represents a single SBOM Doctor finding for a version.
+type DoctorFinding struct {
+	CheckCode        string
+	CheckName        string
+	Severity         string
+	Domain           string
+	ComponentID      string
+	ComponentName    string
+	ComponentVersion string
+	AutoFixable      bool
+	Findings         interface{}
+}
+
+// DoctorPageInfo contains pagination metadata for Doctor findings.
+type DoctorPageInfo struct {
+	EndCursor       string
+	HasNextPage     bool
+	HasPreviousPage bool
+	StartCursor     string
+}
+
+// DoctorResultsResult represents the result of listing Doctor findings.
+type DoctorResultsResult struct {
+	Findings   []DoctorFinding
+	TotalCount int
+	PageInfo   DoctorPageInfo
+}
+
+// ListDoctorResultsInput contains parameters for listing Doctor findings.
+type ListDoctorResultsInput struct {
+	VersionID     string
+	Search        string
+	ComponentID   string
+	Severity      []string
+	Domain        []string
+	CheckCode     []string
+	ComponentName []string
+	ForceRefresh  *bool
+	First         int
+	Last          int
+	After         string
+	Before        string
+}
+
+// ListDoctorResults fetches SBOM Doctor findings for a version.
+func (c *Client) ListDoctorResults(ctx context.Context, input ListDoctorResultsInput) (*DoctorResultsResult, error) {
+	vars := map[string]interface{}{
+		"sbomId": input.VersionID,
+	}
+	if input.Search != "" {
+		vars["search"] = input.Search
+	}
+	if input.ComponentID != "" {
+		vars["componentId"] = input.ComponentID
+	}
+	if len(input.Severity) > 0 {
+		vars["severity"] = input.Severity
+	}
+	if len(input.Domain) > 0 {
+		vars["domain"] = input.Domain
+	}
+	if len(input.CheckCode) > 0 {
+		vars["checkCode"] = input.CheckCode
+	}
+	if len(input.ComponentName) > 0 {
+		vars["componentName"] = input.ComponentName
+	}
+	if input.ForceRefresh != nil {
+		vars["forceRefresh"] = *input.ForceRefresh
+	}
+	if input.First > 0 {
+		vars["first"] = input.First
+	}
+	if input.Last > 0 {
+		vars["last"] = input.Last
+	}
+	if input.After != "" {
+		vars["after"] = input.After
+	}
+	if input.Before != "" {
+		vars["before"] = input.Before
+	}
+	if _, ok := vars["first"]; !ok {
+		if _, ok := vars["last"]; !ok {
+			vars["first"] = 25
+		}
+	}
+
+	var result struct {
+		DoctorResults struct {
+			Nodes []struct {
+				CheckCode        string      `json:"checkCode"`
+				CheckName        string      `json:"checkName"`
+				Severity         string      `json:"severity"`
+				Domain           string      `json:"domain"`
+				ComponentID      string      `json:"componentId"`
+				ComponentName    string      `json:"componentName"`
+				ComponentVersion string      `json:"componentVersion"`
+				AutoFixable      bool        `json:"autoFixable"`
+				Findings         interface{} `json:"findings"`
+			} `json:"nodes"`
+			TotalCount int `json:"totalCount"`
+			PageInfo   struct {
+				EndCursor       string `json:"endCursor"`
+				HasNextPage     bool   `json:"hasNextPage"`
+				HasPreviousPage bool   `json:"hasPreviousPage"`
+				StartCursor     string `json:"startCursor"`
+			} `json:"pageInfo"`
+		} `json:"doctorResults"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.DoctorResultsQuery, vars, &result); err != nil {
+		return nil, err
+	}
+
+	findings := make([]DoctorFinding, len(result.DoctorResults.Nodes))
+	for i, n := range result.DoctorResults.Nodes {
+		findings[i] = DoctorFinding{
+			CheckCode:        n.CheckCode,
+			CheckName:        n.CheckName,
+			Severity:         n.Severity,
+			Domain:           n.Domain,
+			ComponentID:      n.ComponentID,
+			ComponentName:    n.ComponentName,
+			ComponentVersion: n.ComponentVersion,
+			AutoFixable:      n.AutoFixable,
+			Findings:         n.Findings,
+		}
+	}
+
+	return &DoctorResultsResult{
+		Findings:   findings,
+		TotalCount: result.DoctorResults.TotalCount,
+		PageInfo: DoctorPageInfo{
+			EndCursor:       result.DoctorResults.PageInfo.EndCursor,
+			HasNextPage:     result.DoctorResults.PageInfo.HasNextPage,
+			HasPreviousPage: result.DoctorResults.PageInfo.HasPreviousPage,
+			StartCursor:     result.DoctorResults.PageInfo.StartCursor,
+		},
+	}, nil
+}

--- a/internal/api/doctor_test.go
+++ b/internal/api/doctor_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListDoctorResults_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"doctorResults": {
+					"totalCount": 1,
+					"pageInfo": {
+						"endCursor": "cursor-2",
+						"hasNextPage": true,
+						"hasPreviousPage": false,
+						"startCursor": "cursor-1"
+					},
+					"nodes": [
+						{
+							"checkCode": "IDT-PURL-001",
+							"checkName": "PURL conforms to the package-url specification",
+							"severity": "high",
+							"domain": "identity",
+							"componentId": "component-1",
+							"componentName": "openssl",
+							"componentVersion": "3.0.0",
+							"autoFixable": false,
+							"findings": [{"field": "purl", "message": "invalid"}]
+						}
+					]
+				}
+			}`,
+		},
+	}
+	forceRefresh := false
+	client := &Client{gql: gql}
+
+	result, err := client.ListDoctorResults(context.Background(), ListDoctorResultsInput{
+		VersionID:     "version-1",
+		Search:        "open",
+		ComponentID:   "component-1",
+		Severity:      []string{"high"},
+		Domain:        []string{"identity"},
+		CheckCode:     []string{"IDT-PURL-001"},
+		ComponentName: []string{"openssl"},
+		ForceRefresh:  &forceRefresh,
+		First:         25,
+		After:         "cursor-1",
+	})
+	if err != nil {
+		t.Fatalf("ListDoctorResults returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["sbomId"] != "version-1" {
+		t.Fatalf("sbomId = %#v, want version-1", request["sbomId"])
+	}
+	if request["forceRefresh"] != false {
+		t.Fatalf("forceRefresh = %#v, want false", request["forceRefresh"])
+	}
+	if request["first"] != 25 {
+		t.Fatalf("first = %#v, want 25", request["first"])
+	}
+	if request["after"] != "cursor-1" {
+		t.Fatalf("after = %#v, want cursor-1", request["after"])
+	}
+
+	if result.TotalCount != 1 {
+		t.Fatalf("TotalCount = %d, want 1", result.TotalCount)
+	}
+	if !result.PageInfo.HasNextPage || result.PageInfo.StartCursor != "cursor-1" || result.PageInfo.EndCursor != "cursor-2" {
+		t.Fatalf("unexpected PageInfo: %#v", result.PageInfo)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(result.Findings))
+	}
+	finding := result.Findings[0]
+	if finding.CheckCode != "IDT-PURL-001" || finding.ComponentName != "openssl" || finding.Severity != "high" {
+		t.Fatalf("unexpected finding: %#v", finding)
+	}
+}
+
+func TestListDoctorResults_DefaultsFirst(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"doctorResults": {
+					"totalCount": 0,
+					"pageInfo": {
+						"endCursor": "",
+						"hasNextPage": false,
+						"hasPreviousPage": false,
+						"startCursor": ""
+					},
+					"nodes": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	_, err := client.ListDoctorResults(context.Background(), ListDoctorResultsInput{VersionID: "version-1"})
+	if err != nil {
+		t.Fatalf("ListDoctorResults returned error: %v", err)
+	}
+
+	if gql.requests[0]["first"] != 25 {
+		t.Fatalf("first = %#v, want default 25", gql.requests[0]["first"])
+	}
+}

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -473,6 +473,45 @@ const (
 		}
 	`
 
+	// DoctorResultsQuery fetches SBOM Doctor findings for a version
+	DoctorResultsQuery = `
+		query GetDoctorResults($sbomId: Uuid!, $search: String, $componentId: Uuid, $severity: [DoctorSeverityEnum!], $domain: [DoctorDomainEnum!], $checkCode: [String!], $componentName: [String!], $forceRefresh: Boolean, $first: Int, $last: Int, $after: String, $before: String) {
+			doctorResults(
+				sbomId: $sbomId
+				search: $search
+				componentId: $componentId
+				severity: $severity
+				domain: $domain
+				checkCode: $checkCode
+				componentName: $componentName
+				forceRefresh: $forceRefresh
+				first: $first
+				last: $last
+				after: $after
+				before: $before
+			) {
+				totalCount
+				pageInfo {
+					endCursor
+					hasNextPage
+					hasPreviousPage
+					startCursor
+				}
+				nodes {
+					checkCode
+					checkName
+					severity
+					domain
+					componentId
+					componentName
+					componentVersion
+					autoFixable
+					findings
+				}
+			}
+		}
+	`
+
 	// LicensesQuery fetches licenses with pagination
 	LicensesQuery = `
 		query GetLicenses($first: Int, $after: String, $status: [String!], $search: String) {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -201,6 +201,34 @@ func (s *Server) handleVersionVulnerabilitiesResource(ctx context.Context, reque
 	}, nil
 }
 
+func (s *Server) handleVersionDoctorResultsResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	versionID := extractPathParam(request.Params.URI, "version_id")
+	if versionID == "" {
+		return nil, fmt.Errorf("missing version_id in URI")
+	}
+
+	result, err := s.client.ListDoctorResults(ctx, api.ListDoctorResultsInput{
+		VersionID: versionID,
+		First:     25,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Doctor results: %w", err)
+	}
+
+	jsonData, err := json.MarshalIndent(formatDoctorResults(versionID, result), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Doctor results: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(jsonData),
+		},
+	}, nil
+}
+
 func (s *Server) handleEnvironmentLatestVersionResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 	environmentID := extractPathParam(request.Params.URI, "environment_id")
 	if environmentID == "" {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -99,6 +99,22 @@ func (s *Server) registerTools() {
 		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the version")),
 	), s.handleGetVersion)
 
+	s.mcp.AddTool(mcp.NewTool("list_doctor_results",
+		mcp.WithDescription("List SBOM Doctor findings for a version"),
+		mcp.WithString("version_id", mcp.Required(), mcp.Description("The UUID of the version")),
+		mcp.WithString("search", mcp.Description("Case-insensitive substring search on component name")),
+		mcp.WithString("component_id", mcp.Description("Filter to a single component UUID")),
+		mcp.WithArray("severity", mcp.Description("Filter by Doctor severity"), mcp.WithStringItems()),
+		mcp.WithArray("domain", mcp.Description("Filter by Doctor domain"), mcp.WithStringItems()),
+		mcp.WithArray("check_code", mcp.Description("Filter by Doctor check code"), mcp.WithStringItems()),
+		mcp.WithArray("component_name", mcp.Description("Filter by exact component name"), mcp.WithStringItems()),
+		mcp.WithBoolean("force_refresh", mcp.Description("Bypass Doctor cache")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 25, max: 25)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
+		mcp.WithNumber("last", mcp.Description("Maximum number of previous-page results to return (max: 25)")),
+		mcp.WithString("before", mcp.Description("Cursor for the previous page")),
+	), s.handleListDoctorResults)
+
 	s.mcp.AddTool(mcp.NewTool("compare_versions",
 		mcp.WithDescription("Compare two versions and show the differences (drift analysis)"),
 		mcp.WithString("source_version_id", mcp.Required(), mcp.Description("The UUID of the source version")),
@@ -202,6 +218,15 @@ func (s *Server) registerResources() {
 			mcp.WithTemplateMIMEType("application/json"),
 		),
 		s.handleVersionVulnerabilitiesResource,
+	)
+
+	s.mcp.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"version:///{version_id}/doctor-results",
+			"SBOM Doctor findings for a version",
+			mcp.WithTemplateMIMEType("application/json"),
+		),
+		s.handleVersionDoctorResultsResource,
 	)
 
 	s.mcp.AddResourceTemplate(

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -283,6 +283,50 @@ func (s *Server) handleGetVersion(ctx context.Context, request mcp.CallToolReque
 	return formatResult(result)
 }
 
+func (s *Server) handleListDoctorResults(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	versionID, ok := args["version_id"].(string)
+	if !ok || versionID == "" {
+		return newToolResultError("Missing required parameter: version_id"), nil
+	}
+
+	input := api.ListDoctorResultsInput{
+		VersionID:     versionID,
+		Severity:      getStringSliceParam(args, "severity"),
+		Domain:        getStringSliceParam(args, "domain"),
+		CheckCode:     getStringSliceParam(args, "check_code"),
+		ComponentName: getStringSliceParam(args, "component_name"),
+	}
+	if limit := getIntParam(args, "limit", 0); limit > 0 {
+		input.First = limit
+	}
+	if last := getIntParam(args, "last", 0); last > 0 {
+		input.Last = last
+	}
+	if search, ok := args["search"].(string); ok {
+		input.Search = search
+	}
+	if componentID, ok := args["component_id"].(string); ok {
+		input.ComponentID = componentID
+	}
+	if forceRefresh, ok := args["force_refresh"].(bool); ok {
+		input.ForceRefresh = &forceRefresh
+	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
+	if before, ok := args["before"].(string); ok {
+		input.Before = before
+	}
+
+	result, err := s.client.ListDoctorResults(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list Doctor results: %v", err)), nil
+	}
+
+	return formatResult(formatDoctorResults(versionID, result))
+}
+
 func (s *Server) handleCompareVersions(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	sourceVersionID, ok := args["source_version_id"].(string)
@@ -803,4 +847,58 @@ func getIntParam(args map[string]interface{}, key string, defaultVal int) int {
 		}
 	}
 	return defaultVal
+}
+
+func getStringSliceParam(args map[string]interface{}, key string) []string {
+	val, ok := args[key]
+	if !ok {
+		return nil
+	}
+	switch v := val.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			if str, ok := item.(string); ok && str != "" {
+				result = append(result, str)
+			}
+		}
+		return result
+	case string:
+		if v != "" {
+			return []string{v}
+		}
+	}
+	return nil
+}
+
+func formatDoctorResults(versionID string, result *api.DoctorResultsResult) map[string]interface{} {
+	findings := make([]map[string]interface{}, len(result.Findings))
+	for i, f := range result.Findings {
+		findings[i] = map[string]interface{}{
+			"checkCode":        f.CheckCode,
+			"checkName":        f.CheckName,
+			"severity":         f.Severity,
+			"domain":           f.Domain,
+			"componentId":      f.ComponentID,
+			"componentName":    f.ComponentName,
+			"componentVersion": f.ComponentVersion,
+			"autoFixable":      f.AutoFixable,
+			"findings":         f.Findings,
+		}
+	}
+
+	return map[string]interface{}{
+		"versionId":  versionID,
+		"findings":   findings,
+		"totalCount": result.TotalCount,
+		"hasMore":    result.PageInfo.HasNextPage,
+		"pageInfo": map[string]interface{}{
+			"endCursor":       result.PageInfo.EndCursor,
+			"hasNextPage":     result.PageInfo.HasNextPage,
+			"hasPreviousPage": result.PageInfo.HasPreviousPage,
+			"startCursor":     result.PageInfo.StartCursor,
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- add API support for querying SBOM Doctor findings with pagination and filters
- expose Doctor findings through the list_doctor_results MCP tool
- add a version doctor-results MCP resource template
- cover API input/result mapping and default pagination with tests

## Validation
- go test ./...