### PR TITLE
Add component update MCP tools

### DIFF
--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -1,0 +1,374 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+
+	"github.com/interlynk-io/lynk-mcp/internal/graphql"
+)
+
+// LicenseInput contains license data accepted by component mutations.
+type LicenseInput struct {
+	LicensesExp string `json:"licensesExp"`
+}
+
+// ChecksumInput contains checksum data accepted by component mutations.
+type ChecksumInput struct {
+	Alg     string `json:"alg"`
+	Content string `json:"content"`
+}
+
+// ExternalURLInput contains external URL data accepted by component mutations.
+type ExternalURLInput struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// ComponentVulnCustomFieldAttributeInput contains custom VEX field values.
+type ComponentVulnCustomFieldAttributeInput struct {
+	ID                                   string `json:"id,omitempty"`
+	ComponentVulnCustomFieldDefinitionID string `json:"componentVulnCustomFieldDefinitionId,omitempty"`
+	Value                                string `json:"value,omitempty"`
+	Destroy                              *bool  `json:"_destroy,omitempty"`
+}
+
+// ComponentChecksum represents a checksum returned for a component.
+type ComponentChecksum struct {
+	Alg     string
+	Content string
+}
+
+// ComponentExternalURL represents an external URL returned for a component.
+type ComponentExternalURL struct {
+	Name string
+	URL  string
+}
+
+// UpdateComponentInput contains mutable component metadata.
+type UpdateComponentInput struct {
+	ID               string
+	VersionID        string
+	Kind             *string
+	Name             *string
+	Description      *string
+	Copyright        *string
+	Version          *string
+	Group            *string
+	Licenses         *LicenseInput
+	Cpes             *[]string
+	Purl             *string
+	Primary          *bool
+	Internal         *bool
+	GenerateUniqueID *bool
+	Scope            *string
+	SupportLevel     *string
+	EndOfSupport     *string
+	Notice           *string
+	Checksums        *[]ChecksumInput
+	ExternalURLs     *[]ExternalURLInput
+}
+
+// UpdateComponentResult contains the component mutation result.
+type UpdateComponentResult struct {
+	Component *VersionComponent
+	Errors    []string
+}
+
+// ComponentSupplier represents a component supplier.
+type ComponentSupplier struct {
+	ID           string
+	Name         string
+	URL          string
+	ContactName  string
+	ContactEmail string
+}
+
+// UpdateComponentSupplierInput contains mutable component supplier metadata.
+type UpdateComponentSupplierInput struct {
+	ID           string
+	Name         *string
+	URL          *string
+	ContactName  *string
+	ContactEmail *string
+}
+
+// UpdateComponentSupplierResult contains the component supplier mutation result.
+type UpdateComponentSupplierResult struct {
+	Supplier *ComponentSupplier
+	Errors   []string
+}
+
+// UpdateComponentVexInput contains mutable VEX fields for a component vulnerability.
+type UpdateComponentVexInput struct {
+	ComponentVulnID                    string
+	CurrentVersionID                   string
+	VexStatusID                        *string
+	VexJustificationID                 *string
+	CDXResponseID                      *string
+	Note                               *string
+	Impact                             *string
+	Detail                             *string
+	Action                             *string
+	FixedIn                            *string
+	PropagateVex                       *bool
+	ResolutionDate                     *string
+	ComponentVulnCustomFieldAttributes *[]ComponentVulnCustomFieldAttributeInput
+}
+
+// UpdateComponentVexResult contains the VEX mutation result.
+type UpdateComponentVexResult struct {
+	ComponentVuln *ComponentVuln
+	Errors        []string
+}
+
+// UpdateComponent updates mutable component metadata.
+func (c *Client) UpdateComponent(ctx context.Context, input UpdateComponentInput) (*UpdateComponentResult, error) {
+	vars := map[string]interface{}{
+		"id":     input.ID,
+		"sbomId": input.VersionID,
+	}
+	addStringVar(vars, "kind", input.Kind)
+	addStringVar(vars, "name", input.Name)
+	addStringVar(vars, "description", input.Description)
+	addStringVar(vars, "copyright", input.Copyright)
+	addStringVar(vars, "version", input.Version)
+	addStringVar(vars, "group", input.Group)
+	addStringVar(vars, "purl", input.Purl)
+	addStringVar(vars, "scope", input.Scope)
+	addStringVar(vars, "supportLevel", input.SupportLevel)
+	addStringVar(vars, "endOfSupport", input.EndOfSupport)
+	addStringVar(vars, "notice", input.Notice)
+	addBoolVar(vars, "primary", input.Primary)
+	addBoolVar(vars, "internal", input.Internal)
+	addBoolVar(vars, "generateUniqueId", input.GenerateUniqueID)
+	if input.Licenses != nil {
+		vars["licenses"] = input.Licenses
+	}
+	if input.Cpes != nil {
+		vars["cpes"] = *input.Cpes
+	}
+	if input.Checksums != nil {
+		vars["checksums"] = *input.Checksums
+	}
+	if input.ExternalURLs != nil {
+		vars["externalUrls"] = *input.ExternalURLs
+	}
+
+	var result struct {
+		ComponentUpdate struct {
+			Component *struct {
+				ID           string   `json:"id"`
+				Name         string   `json:"name"`
+				Version      string   `json:"version"`
+				Kind         string   `json:"kind"`
+				Purl         string   `json:"purl"`
+				Cpes         []string `json:"cpes"`
+				LicensesExp  string   `json:"licensesExp"`
+				Group        string   `json:"group"`
+				Description  string   `json:"description"`
+				Scope        string   `json:"scope"`
+				Copyright    string   `json:"copyright"`
+				Primary      bool     `json:"primary"`
+				Internal     bool     `json:"internal"`
+				UniqueID     string   `json:"uniqueId"`
+				SbomID       string   `json:"sbomId"`
+				Notice       string   `json:"notice"`
+				SupportLevel string   `json:"supportLevel"`
+				EndOfSupport string   `json:"endOfSupport"`
+				Checksums    []struct {
+					Alg     string `json:"alg"`
+					Content string `json:"content"`
+				} `json:"checksums"`
+				ExternalURLs []struct {
+					Name string `json:"name"`
+					URL  string `json:"url"`
+				} `json:"externalUrls"`
+			} `json:"component"`
+			Errors []string `json:"errors"`
+		} `json:"componentUpdate"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ComponentUpdateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.ComponentUpdate
+	updateResult := &UpdateComponentResult{Errors: mutation.Errors}
+	if mutation.Component != nil {
+		component := &VersionComponent{
+			ID:           mutation.Component.ID,
+			Name:         mutation.Component.Name,
+			Version:      mutation.Component.Version,
+			Kind:         mutation.Component.Kind,
+			Purl:         mutation.Component.Purl,
+			Cpes:         mutation.Component.Cpes,
+			LicensesExp:  mutation.Component.LicensesExp,
+			Group:        mutation.Component.Group,
+			Description:  mutation.Component.Description,
+			Scope:        mutation.Component.Scope,
+			Copyright:    mutation.Component.Copyright,
+			Primary:      mutation.Component.Primary,
+			Internal:     mutation.Component.Internal,
+			UniqueID:     mutation.Component.UniqueID,
+			VersionID:    mutation.Component.SbomID,
+			Notice:       mutation.Component.Notice,
+			SupportLevel: mutation.Component.SupportLevel,
+			EndOfSupport: mutation.Component.EndOfSupport,
+		}
+		component.Checksums = make([]ComponentChecksum, len(mutation.Component.Checksums))
+		for i, checksum := range mutation.Component.Checksums {
+			component.Checksums[i] = ComponentChecksum{Alg: checksum.Alg, Content: checksum.Content}
+		}
+		component.ExternalURLs = make([]ComponentExternalURL, len(mutation.Component.ExternalURLs))
+		for i, externalURL := range mutation.Component.ExternalURLs {
+			component.ExternalURLs[i] = ComponentExternalURL{Name: externalURL.Name, URL: externalURL.URL}
+		}
+		updateResult.Component = component
+	}
+
+	return updateResult, nil
+}
+
+// UpdateComponentSupplier updates component supplier metadata.
+func (c *Client) UpdateComponentSupplier(ctx context.Context, input UpdateComponentSupplierInput) (*UpdateComponentSupplierResult, error) {
+	vars := map[string]interface{}{"id": input.ID}
+	addStringVar(vars, "name", input.Name)
+	addStringVar(vars, "url", input.URL)
+	addStringVar(vars, "contactName", input.ContactName)
+	addStringVar(vars, "contactEmail", input.ContactEmail)
+
+	var result struct {
+		CompSupplierUpdate struct {
+			CompSupplier *struct {
+				ID           string `json:"id"`
+				Name         string `json:"name"`
+				URL          string `json:"url"`
+				ContactName  string `json:"contactName"`
+				ContactEmail string `json:"contactEmail"`
+			} `json:"compSupplier"`
+			Errors []string `json:"errors"`
+		} `json:"compSupplierUpdate"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ComponentSupplierUpdateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.CompSupplierUpdate
+	updateResult := &UpdateComponentSupplierResult{Errors: mutation.Errors}
+	if mutation.CompSupplier != nil {
+		updateResult.Supplier = &ComponentSupplier{
+			ID:           mutation.CompSupplier.ID,
+			Name:         mutation.CompSupplier.Name,
+			URL:          mutation.CompSupplier.URL,
+			ContactName:  mutation.CompSupplier.ContactName,
+			ContactEmail: mutation.CompSupplier.ContactEmail,
+		}
+	}
+
+	return updateResult, nil
+}
+
+// UpdateComponentVex updates VEX data for a component vulnerability.
+func (c *Client) UpdateComponentVex(ctx context.Context, input UpdateComponentVexInput) (*UpdateComponentVexResult, error) {
+	vars := map[string]interface{}{
+		"componentVulnId": input.ComponentVulnID,
+		"currentSbomId":   input.CurrentVersionID,
+	}
+	addStringVar(vars, "vexStatusId", input.VexStatusID)
+	addStringVar(vars, "vexJustificationId", input.VexJustificationID)
+	addStringVar(vars, "cdxResponseId", input.CDXResponseID)
+	addStringVar(vars, "note", input.Note)
+	addStringVar(vars, "impact", input.Impact)
+	addStringVar(vars, "detail", input.Detail)
+	addStringVar(vars, "action", input.Action)
+	addStringVar(vars, "fixedIn", input.FixedIn)
+	addBoolVar(vars, "propagateVex", input.PropagateVex)
+	addStringVar(vars, "resolutionDate", input.ResolutionDate)
+	if input.ComponentVulnCustomFieldAttributes != nil {
+		vars["componentVulnCustomFieldAttributes"] = *input.ComponentVulnCustomFieldAttributes
+	}
+
+	var result struct {
+		ComponentVexUpdate struct {
+			ComponentVuln *struct {
+				ID          string `json:"id"`
+				ComponentID string `json:"componentId"`
+				VulnID      string `json:"vulnId"`
+				SbomID      string `json:"sbomId"`
+				FixedIn     string `json:"fixedIn"`
+				Detail      string `json:"detail"`
+				Impact      string `json:"impact"`
+				ActionStmt  string `json:"actionStmt"`
+				VexStatus   *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"vexStatus"`
+				VexJustification *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"vexJustification"`
+			} `json:"componentVuln"`
+			Errors []string `json:"errors"`
+		} `json:"componentVexUpdate"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ComponentVexUpdateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.ComponentVexUpdate
+	updateResult := &UpdateComponentVexResult{Errors: mutation.Errors}
+	if mutation.ComponentVuln != nil {
+		componentVuln := &ComponentVuln{
+			ID:          mutation.ComponentVuln.ID,
+			ComponentID: mutation.ComponentVuln.ComponentID,
+			VulnID:      mutation.ComponentVuln.VulnID,
+			VersionID:   mutation.ComponentVuln.SbomID,
+			FixedIn:     mutation.ComponentVuln.FixedIn,
+			Detail:      mutation.ComponentVuln.Detail,
+			Impact:      mutation.ComponentVuln.Impact,
+			ActionStmt:  mutation.ComponentVuln.ActionStmt,
+		}
+		if mutation.ComponentVuln.VexStatus != nil {
+			componentVuln.VexStatus = &VexStatus{
+				ID:   mutation.ComponentVuln.VexStatus.ID,
+				Name: mutation.ComponentVuln.VexStatus.Name,
+			}
+		}
+		if mutation.ComponentVuln.VexJustification != nil {
+			componentVuln.VexJustification = &VexJustification{
+				ID:   mutation.ComponentVuln.VexJustification.ID,
+				Name: mutation.ComponentVuln.VexJustification.Name,
+			}
+		}
+		updateResult.ComponentVuln = componentVuln
+	}
+
+	return updateResult, nil
+}
+
+func addStringVar(vars map[string]interface{}, key string, value *string) {
+	if value != nil {
+		vars[key] = *value
+	}
+}
+
+func addBoolVar(vars map[string]interface{}, key string, value *bool) {
+	if value != nil {
+		vars[key] = *value
+	}
+}

--- a/internal/api/mutations_test.go
+++ b/internal/api/mutations_test.go
@@ -1,0 +1,236 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpdateComponent_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentUpdate": {
+					"component": {
+						"id": "component-1",
+						"name": "jest-diff",
+						"version": "27.3.2",
+						"kind": "library",
+						"purl": "",
+						"cpes": [],
+						"licensesExp": "",
+						"group": "npm",
+						"description": "",
+						"scope": "",
+						"copyright": "",
+						"primary": false,
+						"internal": false,
+						"uniqueId": "bom-ref-1",
+						"sbomId": "version-1",
+						"notice": "",
+						"supportLevel": "",
+						"endOfSupport": "",
+						"checksums": [
+							{"alg": "SHA-512", "content": "abc"}
+						],
+						"externalUrls": [
+							{"name": "repo", "url": "https://example.com/repo"}
+						]
+					},
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	kind := "library"
+	name := "jest-diff"
+	empty := ""
+	version := "27.3.2"
+	primary := false
+	internal := false
+	generateUniqueID := true
+	cpes := []string{}
+	checksums := []ChecksumInput{{Alg: "SHA_512", Content: "abc"}}
+	externalURLs := []ExternalURLInput{{Name: "repo", URL: "https://example.com/repo"}}
+
+	result, err := client.UpdateComponent(context.Background(), UpdateComponentInput{
+		ID:               "component-1",
+		VersionID:        "version-1",
+		Kind:             &kind,
+		Name:             &name,
+		Description:      &empty,
+		Version:          &version,
+		Licenses:         &LicenseInput{LicensesExp: ""},
+		Cpes:             &cpes,
+		Purl:             &empty,
+		Primary:          &primary,
+		Internal:         &internal,
+		GenerateUniqueID: &generateUniqueID,
+		Scope:            &empty,
+		Checksums:        &checksums,
+		ExternalURLs:     &externalURLs,
+	})
+	if err != nil {
+		t.Fatalf("UpdateComponent returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["id"] != "component-1" || request["sbomId"] != "version-1" {
+		t.Fatalf("unexpected required variables: %#v", request)
+	}
+	if request["primary"] != false || request["internal"] != false {
+		t.Fatalf("false bools were not preserved: %#v", request)
+	}
+	if request["purl"] != "" || request["description"] != "" {
+		t.Fatalf("empty strings were not preserved: %#v", request)
+	}
+	if got := request["cpes"].([]string); len(got) != 0 {
+		t.Fatalf("cpes = %#v, want empty slice", got)
+	}
+	if request["generateUniqueId"] != true {
+		t.Fatalf("generateUniqueId = %#v, want true", request["generateUniqueId"])
+	}
+	licenses := request["licenses"].(*LicenseInput)
+	if licenses.LicensesExp != "" {
+		t.Fatalf("licensesExp = %q, want empty string", licenses.LicensesExp)
+	}
+
+	if result.Component == nil {
+		t.Fatal("expected updated component")
+	}
+	if result.Component.ID != "component-1" || result.Component.VersionID != "version-1" {
+		t.Fatalf("unexpected component: %#v", result.Component)
+	}
+	if len(result.Component.Checksums) != 1 || result.Component.Checksums[0].Content != "abc" {
+		t.Fatalf("unexpected checksums: %#v", result.Component.Checksums)
+	}
+}
+
+func TestUpdateComponentSupplier_MapsInputsAndErrors(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"compSupplierUpdate": {
+					"compSupplier": null,
+					"errors": ["Component supplier not found"]
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	name := "Supplier"
+	empty := ""
+	result, err := client.UpdateComponentSupplier(context.Background(), UpdateComponentSupplierInput{
+		ID:           "supplier-1",
+		Name:         &name,
+		URL:          &empty,
+		ContactName:  &empty,
+		ContactEmail: &empty,
+	})
+	if err != nil {
+		t.Fatalf("UpdateComponentSupplier returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["id"] != "supplier-1" || request["name"] != "Supplier" {
+		t.Fatalf("unexpected supplier variables: %#v", request)
+	}
+	if request["url"] != "" || request["contactName"] != "" || request["contactEmail"] != "" {
+		t.Fatalf("empty supplier fields were not preserved: %#v", request)
+	}
+	if result.Supplier != nil {
+		t.Fatalf("Supplier = %#v, want nil", result.Supplier)
+	}
+	if len(result.Errors) != 1 || result.Errors[0] != "Component supplier not found" {
+		t.Fatalf("Errors = %#v, want API error", result.Errors)
+	}
+}
+
+func TestUpdateComponentVex_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentVexUpdate": {
+					"componentVuln": {
+						"id": "component-vuln-1",
+						"componentId": "component-1",
+						"vulnId": "vuln-1",
+						"sbomId": "version-1",
+						"fixedIn": "1.2.3",
+						"detail": "detail",
+						"impact": "impact",
+						"actionStmt": "action",
+						"vexStatus": {"id": "status-1", "name": "not_affected"},
+						"vexJustification": {"id": "justification-1", "name": "vulnerable_code_not_present"}
+					},
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	statusID := "status-1"
+	justificationID := "justification-1"
+	note := ""
+	propagateVex := false
+	resolutionDate := "2026-05-07"
+	destroy := false
+	customFields := []ComponentVulnCustomFieldAttributeInput{{
+		ID:                                   "field-value-1",
+		ComponentVulnCustomFieldDefinitionID: "field-def-1",
+		Value:                                "field-value",
+		Destroy:                              &destroy,
+	}}
+
+	result, err := client.UpdateComponentVex(context.Background(), UpdateComponentVexInput{
+		ComponentVulnID:                    "component-vuln-1",
+		CurrentVersionID:                   "version-1",
+		VexStatusID:                        &statusID,
+		VexJustificationID:                 &justificationID,
+		Note:                               &note,
+		PropagateVex:                       &propagateVex,
+		ResolutionDate:                     &resolutionDate,
+		ComponentVulnCustomFieldAttributes: &customFields,
+	})
+	if err != nil {
+		t.Fatalf("UpdateComponentVex returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["componentVulnId"] != "component-vuln-1" || request["currentSbomId"] != "version-1" {
+		t.Fatalf("unexpected VEX required variables: %#v", request)
+	}
+	if request["note"] != "" || request["propagateVex"] != false {
+		t.Fatalf("destructive VEX values were not preserved: %#v", request)
+	}
+	if request["resolutionDate"] != "2026-05-07" {
+		t.Fatalf("resolutionDate = %#v, want 2026-05-07", request["resolutionDate"])
+	}
+	if got := request["componentVulnCustomFieldAttributes"].([]ComponentVulnCustomFieldAttributeInput); len(got) != 1 || got[0].Destroy == nil || *got[0].Destroy {
+		t.Fatalf("unexpected custom fields: %#v", got)
+	}
+
+	if result.ComponentVuln == nil {
+		t.Fatal("expected updated component vuln")
+	}
+	if result.ComponentVuln.VexStatus == nil || result.ComponentVuln.VexStatus.ID != "status-1" {
+		t.Fatalf("unexpected VEX result: %#v", result.ComponentVuln)
+	}
+}

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -57,8 +57,16 @@ type VersionComponent struct {
 	LicensesExp  string
 	Group        string
 	Description  string
+	Scope        string
+	Copyright    string
 	Primary      bool
 	Internal     bool
+	UniqueID     string
+	Notice       string
+	SupportLevel string
+	EndOfSupport string
+	Checksums    []ComponentChecksum
+	ExternalURLs []ComponentExternalURL
 	VersionID    string
 	UpdatedAt    time.Time
 	VersionInfo  *Version

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -239,6 +239,92 @@ const (
 		}
 	`
 
+	// ComponentUpdateMutation updates mutable component metadata for an SBOM component
+	ComponentUpdateMutation = `
+		mutation UpdateComponent($id: Uuid!, $sbomId: Uuid!, $kind: String, $name: String, $description: String, $copyright: String, $version: String, $group: String, $licenses: LicenseInput, $cpes: [String!], $purl: String, $primary: Boolean, $internal: Boolean, $generateUniqueId: Boolean, $scope: String, $supportLevel: ComponentSupportLevelEnum, $endOfSupport: DateOrEmptyString, $notice: String, $checksums: [ChecksumInput!], $externalUrls: [ExternalUrlInput!]) {
+			componentUpdate(
+				input: {id: $id, sbomId: $sbomId, kind: $kind, name: $name, copyright: $copyright, description: $description, version: $version, group: $group, licenses: $licenses, cpes: $cpes, purl: $purl, scope: $scope, primary: $primary, internal: $internal, generateUniqueId: $generateUniqueId, supportLevel: $supportLevel, endOfSupport: $endOfSupport, notice: $notice, checksums: $checksums, externalUrls: $externalUrls}
+			) {
+				component {
+					id
+					name
+					version
+					kind
+					purl
+					cpes
+					licensesExp
+					group
+					description
+					scope
+					copyright
+					primary
+					internal
+					uniqueId
+					sbomId
+					notice
+					supportLevel
+					endOfSupport
+					checksums {
+						alg
+						content
+					}
+					externalUrls {
+						name
+						url
+					}
+				}
+				errors
+			}
+		}
+	`
+
+	// ComponentSupplierUpdateMutation updates a component supplier
+	ComponentSupplierUpdateMutation = `
+		mutation UpdateComponentSupplier($id: Uuid!, $name: String, $url: String, $contactName: String, $contactEmail: String) {
+			compSupplierUpdate(
+				input: {id: $id, name: $name, url: $url, contactName: $contactName, contactEmail: $contactEmail}
+			) {
+				compSupplier {
+					id
+					name
+					url
+					contactName
+					contactEmail
+				}
+				errors
+			}
+		}
+	`
+
+	// ComponentVexUpdateMutation updates VEX data for a component vulnerability
+	ComponentVexUpdateMutation = `
+		mutation UpdateComponentVex($componentVulnId: Uuid!, $currentSbomId: Uuid!, $vexStatusId: Uuid, $vexJustificationId: Uuid, $cdxResponseId: Uuid, $note: String, $impact: String, $detail: String, $action: String, $fixedIn: String, $propagateVex: Boolean, $resolutionDate: ISO8601Date, $componentVulnCustomFieldAttributes: [ComponentVulnCustomFieldAttributesInput!]) {
+			componentVexUpdate(
+				input: {componentVulnId: $componentVulnId, currentSbomId: $currentSbomId, vexStatusId: $vexStatusId, vexJustificationId: $vexJustificationId, cdxResponseId: $cdxResponseId, note: $note, impact: $impact, detail: $detail, action: $action, fixedIn: $fixedIn, propagateVex: $propagateVex, resolutionDate: $resolutionDate, componentVulnCustomFieldAttributes: $componentVulnCustomFieldAttributes}
+			) {
+				componentVuln {
+					id
+					componentId
+					vulnId
+					sbomId
+					fixedIn
+					detail
+					impact
+					actionStmt
+					vexStatus {
+						id
+						name
+					}
+					vexJustification {
+						id
+						name
+					}
+				}
+				errors
+			}
+		}
+	`
+
 	// SbomVulnsQuery fetches vulnerabilities for an SBOM
 	SbomVulnsQuery = `
 		query GetSbomVulns($sbomId: Uuid!, $first: Int, $after: String, $severity: [String!], $status: [String!], $kev: Boolean, $search: String) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -137,6 +137,57 @@ func (s *Server) registerTools() {
 		mcp.WithString("version_id", mcp.Required(), mcp.Description("The UUID of the version containing the component")),
 	), s.handleGetComponent)
 
+	s.mcp.AddTool(mcp.NewTool("update_component",
+		mcp.WithDescription("Destructively update component metadata. Requires confirm=true. Fetch the component first and only pass fields that should change."),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the component to update")),
+		mcp.WithString("version_id", mcp.Required(), mcp.Description("The UUID of the version/SBOM containing the component")),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to perform this destructive update")),
+		mcp.WithString("kind", mcp.Description("Component kind")),
+		mcp.WithString("name", mcp.Description("Component name")),
+		mcp.WithString("description", mcp.Description("Component description")),
+		mcp.WithString("copyright", mcp.Description("Component copyright")),
+		mcp.WithString("version", mcp.Description("Component version")),
+		mcp.WithString("group", mcp.Description("Component group")),
+		mcp.WithObject("licenses", mcp.Description("License input object"), mcp.Properties(map[string]interface{}{
+			"licensesExp": map[string]interface{}{"type": "string", "description": "SPDX license expression"},
+		})),
+		mcp.WithString("licenses_exp", mcp.Description("Convenience SPDX license expression; ignored if licenses is provided")),
+		mcp.WithArray("cpes", mcp.Description("Component CPEs"), mcp.WithStringItems()),
+		mcp.WithString("purl", mcp.Description("Component package URL")),
+		mcp.WithBoolean("primary", mcp.Description("Whether this is the primary component")),
+		mcp.WithBoolean("internal", mcp.Description("Whether this component is internal")),
+		mcp.WithBoolean("generate_unique_id", mcp.Description("Generate a new component unique ID")),
+		mcp.WithString("scope", mcp.Description("Component scope")),
+		mcp.WithString("support_level", mcp.Description("Component support level enum: UNSPECIFIED, ACTIVELY_MAINTAINED, NO_LONGER_MAINTAINED, ABANDONED, NONE")),
+		mcp.WithString("end_of_support", mcp.Description("End-of-support date or empty string")),
+		mcp.WithString("notice", mcp.Description("Component notice")),
+		mcp.WithArray("checksums", mcp.Description("Checksum objects with alg and content"), mcp.Items(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"alg":     map[string]interface{}{"type": "string"},
+				"content": map[string]interface{}{"type": "string"},
+			},
+			"required": []string{"alg", "content"},
+		})),
+		mcp.WithArray("external_urls", mcp.Description("External URL objects with name and url"), mcp.Items(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"name": map[string]interface{}{"type": "string"},
+				"url":  map[string]interface{}{"type": "string"},
+			},
+		})),
+	), s.handleUpdateComponent)
+
+	s.mcp.AddTool(mcp.NewTool("update_component_supplier",
+		mcp.WithDescription("Destructively update a component supplier. Requires confirm=true. Only pass fields that should change."),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the component supplier to update")),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to perform this destructive update")),
+		mcp.WithString("name", mcp.Description("Supplier name")),
+		mcp.WithString("url", mcp.Description("Supplier URL")),
+		mcp.WithString("contact_name", mcp.Description("Supplier contact name")),
+		mcp.WithString("contact_email", mcp.Description("Supplier contact email")),
+	), s.handleUpdateComponentSupplier)
+
 	// Vulnerability tools
 	s.mcp.AddTool(mcp.NewTool("list_vulnerabilities",
 		mcp.WithDescription("List vulnerabilities in a version with optional filters"),
@@ -152,6 +203,32 @@ func (s *Server) registerTools() {
 		mcp.WithDescription("Get details of a specific vulnerability"),
 		mcp.WithString("vuln_id", mcp.Required(), mcp.Description("The CVE ID (e.g., CVE-2021-44228) or UUID")),
 	), s.handleGetVulnerability)
+
+	s.mcp.AddTool(mcp.NewTool("update_component_vex",
+		mcp.WithDescription("Destructively update VEX data for a component vulnerability. Requires confirm=true. Only pass fields that should change."),
+		mcp.WithString("component_vuln_id", mcp.Required(), mcp.Description("The UUID of the component vulnerability to update")),
+		mcp.WithString("current_version_id", mcp.Required(), mcp.Description("The UUID of the current version/SBOM context")),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to perform this destructive update")),
+		mcp.WithString("vex_status_id", mcp.Description("VEX status UUID")),
+		mcp.WithString("vex_justification_id", mcp.Description("VEX justification UUID")),
+		mcp.WithString("cdx_response_id", mcp.Description("CycloneDX response UUID")),
+		mcp.WithString("note", mcp.Description("VEX note")),
+		mcp.WithString("impact", mcp.Description("Impact statement")),
+		mcp.WithString("detail", mcp.Description("Detail statement")),
+		mcp.WithString("action", mcp.Description("Action statement")),
+		mcp.WithString("fixed_in", mcp.Description("Fixed-in value")),
+		mcp.WithBoolean("propagate_vex", mcp.Description("Propagate VEX to upstream")),
+		mcp.WithString("resolution_date", mcp.Description("Resolution date in YYYY-MM-DD format")),
+		mcp.WithArray("component_vuln_custom_field_attributes", mcp.Description("Custom field attribute objects"), mcp.Items(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id":                                   map[string]interface{}{"type": "string"},
+				"componentVulnCustomFieldDefinitionId": map[string]interface{}{"type": "string"},
+				"value":                                map[string]interface{}{"type": "string"},
+				"_destroy":                             map[string]interface{}{"type": "boolean"},
+			},
+		})),
+	), s.handleUpdateComponentVex)
 
 	s.mcp.AddTool(mcp.NewTool("search_vulnerabilities",
 		mcp.WithDescription("Search vulnerabilities across all products"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -472,6 +472,114 @@ func (s *Server) handleGetComponent(ctx context.Context, request mcp.CallToolReq
 	return formatResult(result)
 }
 
+func (s *Server) handleUpdateComponent(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for update_component"), nil
+	}
+
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+	versionID, ok := args["version_id"].(string)
+	if !ok || versionID == "" {
+		return newToolResultError("Missing required parameter: version_id"), nil
+	}
+	if !hasAnyParam(args, "kind", "name", "description", "copyright", "version", "group", "licenses", "licenses_exp", "cpes", "purl", "primary", "internal", "generate_unique_id", "scope", "support_level", "end_of_support", "notice", "checksums", "external_urls") {
+		return newToolResultError("No update fields provided"), nil
+	}
+
+	input := api.UpdateComponentInput{
+		ID:               id,
+		VersionID:        versionID,
+		Kind:             getStringPtrParam(args, "kind"),
+		Name:             getStringPtrParam(args, "name"),
+		Description:      getStringPtrParam(args, "description"),
+		Copyright:        getStringPtrParam(args, "copyright"),
+		Version:          getStringPtrParam(args, "version"),
+		Group:            getStringPtrParam(args, "group"),
+		Cpes:             getStringSlicePtrParam(args, "cpes"),
+		Purl:             getStringPtrParam(args, "purl"),
+		Primary:          getBoolPtrParam(args, "primary"),
+		Internal:         getBoolPtrParam(args, "internal"),
+		GenerateUniqueID: getBoolPtrParam(args, "generate_unique_id"),
+		Scope:            getStringPtrParam(args, "scope"),
+		SupportLevel:     getStringPtrParam(args, "support_level"),
+		EndOfSupport:     getStringPtrParam(args, "end_of_support"),
+		Notice:           getStringPtrParam(args, "notice"),
+	}
+
+	licenses, err := getLicenseInputParam(args)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	input.Licenses = licenses
+	checksums, err := getChecksumInputsParam(args, "checksums")
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	input.Checksums = checksums
+	externalURLs, err := getExternalURLInputsParam(args, "external_urls")
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	input.ExternalURLs = externalURLs
+
+	result, err := s.client.UpdateComponent(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to update component: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to update component: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.Component == nil {
+		return newToolResultError("Failed to update component: API returned no component"), nil
+	}
+
+	return formatResult(formatComponent(result.Component))
+}
+
+func (s *Server) handleUpdateComponentSupplier(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for update_component_supplier"), nil
+	}
+
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+	if !hasAnyParam(args, "name", "url", "contact_name", "contact_email") {
+		return newToolResultError("No update fields provided"), nil
+	}
+
+	result, err := s.client.UpdateComponentSupplier(ctx, api.UpdateComponentSupplierInput{
+		ID:           id,
+		Name:         getStringPtrParam(args, "name"),
+		URL:          getStringPtrParam(args, "url"),
+		ContactName:  getStringPtrParam(args, "contact_name"),
+		ContactEmail: getStringPtrParam(args, "contact_email"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to update component supplier: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to update component supplier: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.Supplier == nil {
+		return newToolResultError("Failed to update component supplier: API returned no supplier"), nil
+	}
+
+	return formatResult(map[string]interface{}{
+		"id":           result.Supplier.ID,
+		"name":         result.Supplier.Name,
+		"url":          result.Supplier.URL,
+		"contactName":  result.Supplier.ContactName,
+		"contactEmail": result.Supplier.ContactEmail,
+	})
+}
+
 func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	versionID, ok := args["version_id"].(string)
@@ -592,6 +700,57 @@ func (s *Server) handleGetVulnerability(ctx context.Context, request mcp.CallToo
 	}
 
 	return formatResult(result)
+}
+
+func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for update_component_vex"), nil
+	}
+
+	componentVulnID, ok := args["component_vuln_id"].(string)
+	if !ok || componentVulnID == "" {
+		return newToolResultError("Missing required parameter: component_vuln_id"), nil
+	}
+	currentVersionID, ok := args["current_version_id"].(string)
+	if !ok || currentVersionID == "" {
+		return newToolResultError("Missing required parameter: current_version_id"), nil
+	}
+	if !hasAnyParam(args, "vex_status_id", "vex_justification_id", "cdx_response_id", "note", "impact", "detail", "action", "fixed_in", "propagate_vex", "resolution_date", "component_vuln_custom_field_attributes") {
+		return newToolResultError("No update fields provided"), nil
+	}
+
+	customFields, err := getComponentVulnCustomFieldInputsParam(args, "component_vuln_custom_field_attributes")
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+
+	result, err := s.client.UpdateComponentVex(ctx, api.UpdateComponentVexInput{
+		ComponentVulnID:                    componentVulnID,
+		CurrentVersionID:                   currentVersionID,
+		VexStatusID:                        getStringPtrParam(args, "vex_status_id"),
+		VexJustificationID:                 getStringPtrParam(args, "vex_justification_id"),
+		CDXResponseID:                      getStringPtrParam(args, "cdx_response_id"),
+		Note:                               getStringPtrParam(args, "note"),
+		Impact:                             getStringPtrParam(args, "impact"),
+		Detail:                             getStringPtrParam(args, "detail"),
+		Action:                             getStringPtrParam(args, "action"),
+		FixedIn:                            getStringPtrParam(args, "fixed_in"),
+		PropagateVex:                       getBoolPtrParam(args, "propagate_vex"),
+		ResolutionDate:                     getStringPtrParam(args, "resolution_date"),
+		ComponentVulnCustomFieldAttributes: customFields,
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to update component VEX: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to update component VEX: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.ComponentVuln == nil {
+		return newToolResultError("Failed to update component VEX: API returned no component vulnerability"), nil
+	}
+
+	return formatResult(formatComponentVuln(result.ComponentVuln))
 }
 
 func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -871,6 +1030,225 @@ func getStringSliceParam(args map[string]interface{}, key string) []string {
 		}
 	}
 	return nil
+}
+
+func confirmed(args map[string]interface{}) bool {
+	confirm, ok := args["confirm"].(bool)
+	return ok && confirm
+}
+
+func hasAnyParam(args map[string]interface{}, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := args[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func getStringPtrParam(args map[string]interface{}, key string) *string {
+	val, ok := args[key]
+	if !ok {
+		return nil
+	}
+	str, ok := val.(string)
+	if !ok {
+		return nil
+	}
+	return &str
+}
+
+func getBoolPtrParam(args map[string]interface{}, key string) *bool {
+	val, ok := args[key]
+	if !ok {
+		return nil
+	}
+	boolean, ok := val.(bool)
+	if !ok {
+		return nil
+	}
+	return &boolean
+}
+
+func getStringSlicePtrParam(args map[string]interface{}, key string) *[]string {
+	if _, ok := args[key]; !ok {
+		return nil
+	}
+	values := getStringSliceParam(args, key)
+	return &values
+}
+
+func getLicenseInputParam(args map[string]interface{}) (*api.LicenseInput, error) {
+	if val, ok := args["licenses"]; ok {
+		obj, ok := val.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("licenses must be an object")
+		}
+		licensesExp, _ := obj["licensesExp"].(string)
+		if licensesExp == "" {
+			licensesExp, _ = obj["licenses_exp"].(string)
+		}
+		return &api.LicenseInput{LicensesExp: licensesExp}, nil
+	}
+	if licensesExp := getStringPtrParam(args, "licenses_exp"); licensesExp != nil {
+		return &api.LicenseInput{LicensesExp: *licensesExp}, nil
+	}
+	return nil, nil
+}
+
+func getChecksumInputsParam(args map[string]interface{}, key string) (*[]api.ChecksumInput, error) {
+	val, ok := args[key]
+	if !ok {
+		return nil, nil
+	}
+	items, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	result := make([]api.ChecksumInput, 0, len(items))
+	for i, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be an object", key, i)
+		}
+		alg, _ := obj["alg"].(string)
+		content, _ := obj["content"].(string)
+		if alg == "" || content == "" {
+			return nil, fmt.Errorf("%s[%d] requires alg and content", key, i)
+		}
+		result = append(result, api.ChecksumInput{Alg: alg, Content: content})
+	}
+	return &result, nil
+}
+
+func getExternalURLInputsParam(args map[string]interface{}, key string) (*[]api.ExternalURLInput, error) {
+	val, ok := args[key]
+	if !ok {
+		return nil, nil
+	}
+	items, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	result := make([]api.ExternalURLInput, 0, len(items))
+	for i, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be an object", key, i)
+		}
+		name, _ := obj["name"].(string)
+		url, _ := obj["url"].(string)
+		if name == "" && url == "" {
+			return nil, fmt.Errorf("%s[%d] requires name or url", key, i)
+		}
+		result = append(result, api.ExternalURLInput{Name: name, URL: url})
+	}
+	return &result, nil
+}
+
+func getComponentVulnCustomFieldInputsParam(args map[string]interface{}, key string) (*[]api.ComponentVulnCustomFieldAttributeInput, error) {
+	val, ok := args[key]
+	if !ok {
+		return nil, nil
+	}
+	items, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	result := make([]api.ComponentVulnCustomFieldAttributeInput, 0, len(items))
+	for i, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be an object", key, i)
+		}
+		input := api.ComponentVulnCustomFieldAttributeInput{}
+		input.ID, _ = obj["id"].(string)
+		input.ComponentVulnCustomFieldDefinitionID, _ = obj["componentVulnCustomFieldDefinitionId"].(string)
+		if input.ComponentVulnCustomFieldDefinitionID == "" {
+			input.ComponentVulnCustomFieldDefinitionID, _ = obj["component_vuln_custom_field_definition_id"].(string)
+		}
+		input.Value, _ = obj["value"].(string)
+		if destroy, ok := obj["_destroy"].(bool); ok {
+			input.Destroy = &destroy
+		} else if destroy, ok := obj["destroy"].(bool); ok {
+			input.Destroy = &destroy
+		}
+		result = append(result, input)
+	}
+	return &result, nil
+}
+
+func formatComponent(component *api.VersionComponent) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":           component.ID,
+		"name":         component.Name,
+		"version":      component.Version,
+		"kind":         component.Kind,
+		"purl":         component.Purl,
+		"cpes":         component.Cpes,
+		"licensesExp":  component.LicensesExp,
+		"group":        component.Group,
+		"description":  component.Description,
+		"scope":        component.Scope,
+		"copyright":    component.Copyright,
+		"primary":      component.Primary,
+		"internal":     component.Internal,
+		"uniqueId":     component.UniqueID,
+		"versionId":    component.VersionID,
+		"notice":       component.Notice,
+		"supportLevel": component.SupportLevel,
+		"endOfSupport": component.EndOfSupport,
+	}
+	if !component.UpdatedAt.IsZero() {
+		result["updatedAt"] = component.UpdatedAt
+	}
+	if component.Checksums != nil {
+		checksums := make([]map[string]interface{}, len(component.Checksums))
+		for i, checksum := range component.Checksums {
+			checksums[i] = map[string]interface{}{
+				"alg":     checksum.Alg,
+				"content": checksum.Content,
+			}
+		}
+		result["checksums"] = checksums
+	}
+	if component.ExternalURLs != nil {
+		externalURLs := make([]map[string]interface{}, len(component.ExternalURLs))
+		for i, externalURL := range component.ExternalURLs {
+			externalURLs[i] = map[string]interface{}{
+				"name": externalURL.Name,
+				"url":  externalURL.URL,
+			}
+		}
+		result["externalUrls"] = externalURLs
+	}
+	return result
+}
+
+func formatComponentVuln(componentVuln *api.ComponentVuln) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":          componentVuln.ID,
+		"componentId": componentVuln.ComponentID,
+		"vulnId":      componentVuln.VulnID,
+		"versionId":   componentVuln.VersionID,
+		"fixedIn":     componentVuln.FixedIn,
+		"detail":      componentVuln.Detail,
+		"impact":      componentVuln.Impact,
+		"actionStmt":  componentVuln.ActionStmt,
+	}
+	if componentVuln.VexStatus != nil {
+		result["vexStatus"] = map[string]interface{}{
+			"id":   componentVuln.VexStatus.ID,
+			"name": componentVuln.VexStatus.Name,
+		}
+	}
+	if componentVuln.VexJustification != nil {
+		result["vexJustification"] = map[string]interface{}{
+			"id":   componentVuln.VexJustification.ID,
+			"name": componentVuln.VexJustification.Name,
+		}
+	}
+	return result
 }
 
 func formatDoctorResults(versionID string, result *api.DoctorResultsResult) map[string]interface{} {


### PR DESCRIPTION
## Summary
- Add MCP tools for updating component metadata, component suppliers, and component VEX data
- Add GraphQL mutation client support and result mapping for those update paths
- Require explicit confirm=true for destructive update tools and preserve empty strings/false booleans in mutation variables

## Validation
- gofmt -w internal/api/mutations.go internal/api/mutations_test.go internal/api/versions.go internal/graphql/queries.go internal/mcp/server.go internal/mcp/tools.go
- go test ./...