### PR TITLE
Use Go 1.25.5 in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use buildx for multi-platform builds
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine AS builder
 LABEL org.opencontainers.image.source="https://github.com/interlynk-io/lynk-mcp"
 
 RUN apk add --no-cache make git


### PR DESCRIPTION
## Summary
- Update the Docker builder image from Go 1.24 to Go 1.25.5
- Match the Go version required by go.mod so image builds do not fail at go mod download

## CI failure
The release image job failed with:

```
go: go.mod requires go >= 1.25.5 (running go 1.24.13; GOTOOLCHAIN=local)
```

## Validation
- go test ./...
- docker build --target builder .