### PR TITLE
fix: accept service token prefixes for live and staging environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-all: ## Build binaries for all platforms
 .PHONY: install
 install: build ## Install binary to GOBIN
 	@echo "Installing $(BINARY_NAME) to $(GOBIN)..."
-	@install -m 755 $(BUILD_DIR)/$(BINARY_NAME) $(GOBIN)/$(BINARY_NAME)
+	@mkdir -p $(GOBIN) && cp $(BUILD_DIR)/$(BINARY_NAME) $(GOBIN)/$(BINARY_NAME) && chmod 755 $(GOBIN)/$(BINARY_NAME)
 	@echo "Installed to $(GOBIN)/$(BINARY_NAME)"
 
 ##@ Running

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ cd lynk-mcp
 make build
 ```
 
+The binary is placed in `./build/lynk-mcp`. You can run it directly from there, or run `make install` to install it to `$GOPATH/bin` (typically `~/go/bin`) and use it from anywhere.
+
 ## Configuration
 
 ### Initial Setup
@@ -334,6 +336,7 @@ Add to `~/.config/zed/settings.json`:
 
 ```bash
 make build          # Build for current platform
+make install        # Build and install to $GOPATH/bin
 make build-all      # Build for all platforms
 make test           # Run tests
 make lint           # Run linter
@@ -375,5 +378,3 @@ Apache License 2.0
 ---
 
 Made with care by [Interlynk.io](https://www.interlynk.io)
-
-d

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -31,6 +31,8 @@ var validTokenPrefixes = []string{
 	"lynk_live_",
 	"lynk_staging_",
 	"lynk_test_",
+	"lynk_service_live_",
+	"lynk_service_staging_",
 	"lynk_service_test_",
 }
 

--- a/internal/config/keyring_test.go
+++ b/internal/config/keyring_test.go
@@ -24,6 +24,8 @@ func TestValidateTokenFormat_AcceptsKnownPrefixes(t *testing.T) {
 		"lynk_live_abc",
 		"lynk_staging_abc",
 		"lynk_test_abc",
+		"lynk_service_live_abc",
+		"lynk_service_staging_abc",
 		"lynk_service_test_abc",
 	}
 
@@ -37,8 +39,6 @@ func TestValidateTokenFormat_AcceptsKnownPrefixes(t *testing.T) {
 func TestValidateTokenFormat_RejectsUnknownPrefixes(t *testing.T) {
 	tokens := []string{
 		"",
-		"lynk_service_live_abc",
-		"lynk_service_staging_abc",
 		"other_test_abc",
 	}
 


### PR DESCRIPTION
## Summary
- Add `lynk_service_live_` and `lynk_service_staging_` to valid token prefixes in keyring validation
- Update tests to reflect these are valid (not rejected) prefixes
- Robustify `make install` to create `$GOBIN` if it doesn't exist
- Document `make install` in README and fix trailing garbage at end of file

## Test plan
- [ ] `make test` passes
- [ ] Service tokens with `lynk_service_live_` and `lynk_service_staging_` prefixes are accepted
- [ ] `make install` works even when `$GOBIN` doesn't exist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)