### PR TITLE
Add VEX ID lookup tools

### DIFF
--- a/internal/api/vulnerabilities_test.go
+++ b/internal/api/vulnerabilities_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetVexStatuses(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"vexStatuses": [
+					{"id": "status-1", "name": "affected"},
+					{"id": "status-2", "name": "not_affected"}
+				]
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	statuses, err := client.GetVexStatuses(context.Background())
+	if err != nil {
+		t.Fatalf("GetVexStatuses returned error: %v", err)
+	}
+
+	if len(statuses) != 2 {
+		t.Fatalf("len(statuses) = %d, want 2", len(statuses))
+	}
+	if statuses[1].ID != "status-2" || statuses[1].Name != "not_affected" {
+		t.Fatalf("unexpected statuses: %#v", statuses)
+	}
+}
+
+func TestGetVexJustifications(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"vexJustifications": [
+					{"id": "justification-1", "name": "vulnerable_code_not_present"},
+					{"id": "justification-2", "name": "component_not_present"}
+				]
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	justifications, err := client.GetVexJustifications(context.Background())
+	if err != nil {
+		t.Fatalf("GetVexJustifications returned error: %v", err)
+	}
+
+	if len(justifications) != 2 {
+		t.Fatalf("len(justifications) = %d, want 2", len(justifications))
+	}
+	if justifications[0].ID != "justification-1" || justifications[0].Name != "vulnerable_code_not_present" {
+		t.Fatalf("unexpected justifications: %#v", justifications)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -204,13 +204,23 @@ func (s *Server) registerTools() {
 		mcp.WithString("vuln_id", mcp.Required(), mcp.Description("The CVE ID (e.g., CVE-2021-44228) or UUID")),
 	), s.handleGetVulnerability)
 
+	s.mcp.AddTool(mcp.NewTool("list_vex_statuses",
+		mcp.WithDescription("List VEX statuses with UUIDs for CVE triage"),
+	), s.handleListVexStatuses)
+
+	s.mcp.AddTool(mcp.NewTool("list_vex_justifications",
+		mcp.WithDescription("List VEX justifications with UUIDs for CVE triage"),
+	), s.handleListVexJustifications)
+
 	s.mcp.AddTool(mcp.NewTool("update_component_vex",
-		mcp.WithDescription("Destructively update VEX data for a component vulnerability. Requires confirm=true. Only pass fields that should change."),
+		mcp.WithDescription("Destructively update VEX data for a component vulnerability. Requires confirm=true. Only pass fields that should change. Status and justification may be supplied by UUID or by name."),
 		mcp.WithString("component_vuln_id", mcp.Required(), mcp.Description("The UUID of the component vulnerability to update")),
 		mcp.WithString("current_version_id", mcp.Required(), mcp.Description("The UUID of the current version/SBOM context")),
 		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to perform this destructive update")),
 		mcp.WithString("vex_status_id", mcp.Description("VEX status UUID")),
+		mcp.WithString("vex_status", mcp.Description("VEX status name (e.g., affected, not_affected, fixed); resolved to UUID automatically")),
 		mcp.WithString("vex_justification_id", mcp.Description("VEX justification UUID")),
+		mcp.WithString("vex_justification", mcp.Description("VEX justification name (e.g., vulnerable_code_not_present); resolved to UUID automatically")),
 		mcp.WithString("cdx_response_id", mcp.Description("CycloneDX response UUID")),
 		mcp.WithString("note", mcp.Description("VEX note")),
 		mcp.WithString("impact", mcp.Description("Impact statement")),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -644,9 +644,11 @@ func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.Call
 		}
 		if cv.VexStatus != nil {
 			vuln["vexStatus"] = cv.VexStatus.Name
+			vuln["vexStatusId"] = cv.VexStatus.ID
 		}
 		if cv.VexJustification != nil {
 			vuln["vexJustification"] = cv.VexJustification.Name
+			vuln["vexJustificationId"] = cv.VexJustification.ID
 		}
 		vulns[i] = vuln
 	}
@@ -702,6 +704,44 @@ func (s *Server) handleGetVulnerability(ctx context.Context, request mcp.CallToo
 	return formatResult(result)
 }
 
+func (s *Server) handleListVexStatuses(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	statuses, err := s.client.GetVexStatuses(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list VEX statuses: %v", err)), nil
+	}
+
+	result := make([]map[string]interface{}, len(statuses))
+	for i, status := range statuses {
+		result[i] = map[string]interface{}{
+			"id":   status.ID,
+			"name": status.Name,
+		}
+	}
+
+	return formatResult(map[string]interface{}{
+		"vexStatuses": result,
+	})
+}
+
+func (s *Server) handleListVexJustifications(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	justifications, err := s.client.GetVexJustifications(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list VEX justifications: %v", err)), nil
+	}
+
+	result := make([]map[string]interface{}, len(justifications))
+	for i, justification := range justifications {
+		result[i] = map[string]interface{}{
+			"id":   justification.ID,
+			"name": justification.Name,
+		}
+	}
+
+	return formatResult(map[string]interface{}{
+		"vexJustifications": result,
+	})
+}
+
 func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	if !confirmed(args) {
@@ -716,7 +756,7 @@ func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallT
 	if !ok || currentVersionID == "" {
 		return newToolResultError("Missing required parameter: current_version_id"), nil
 	}
-	if !hasAnyParam(args, "vex_status_id", "vex_justification_id", "cdx_response_id", "note", "impact", "detail", "action", "fixed_in", "propagate_vex", "resolution_date", "component_vuln_custom_field_attributes") {
+	if !hasAnyParam(args, "vex_status_id", "vex_status", "vex_justification_id", "vex_justification", "cdx_response_id", "note", "impact", "detail", "action", "fixed_in", "propagate_vex", "resolution_date", "component_vuln_custom_field_attributes") {
 		return newToolResultError("No update fields provided"), nil
 	}
 
@@ -725,11 +765,20 @@ func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallT
 		return newToolResultError(err.Error()), nil
 	}
 
+	vexStatusID, err := s.resolveVexStatusID(ctx, args)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	vexJustificationID, err := s.resolveVexJustificationID(ctx, args)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+
 	result, err := s.client.UpdateComponentVex(ctx, api.UpdateComponentVexInput{
 		ComponentVulnID:                    componentVulnID,
 		CurrentVersionID:                   currentVersionID,
-		VexStatusID:                        getStringPtrParam(args, "vex_status_id"),
-		VexJustificationID:                 getStringPtrParam(args, "vex_justification_id"),
+		VexStatusID:                        vexStatusID,
+		VexJustificationID:                 vexJustificationID,
 		CDXResponseID:                      getStringPtrParam(args, "cdx_response_id"),
 		Note:                               getStringPtrParam(args, "note"),
 		Impact:                             getStringPtrParam(args, "impact"),
@@ -803,6 +852,11 @@ func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.Ca
 		}
 		if cv.VexStatus != nil {
 			vuln["vexStatus"] = cv.VexStatus.Name
+			vuln["vexStatusId"] = cv.VexStatus.ID
+		}
+		if cv.VexJustification != nil {
+			vuln["vexJustification"] = cv.VexJustification.Name
+			vuln["vexJustificationId"] = cv.VexJustification.ID
 		}
 		vulns[i] = vuln
 	}
@@ -1068,6 +1122,76 @@ func getBoolPtrParam(args map[string]interface{}, key string) *bool {
 		return nil
 	}
 	return &boolean
+}
+
+func (s *Server) resolveVexStatusID(ctx context.Context, args map[string]interface{}) (*string, error) {
+	if id := getStringPtrParam(args, "vex_status_id"); id != nil && *id != "" {
+		return id, nil
+	}
+
+	name := strings.TrimSpace(stringParam(args, "vex_status"))
+	if name == "" {
+		return nil, nil
+	}
+
+	statuses, err := s.client.GetVexStatuses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve VEX status %q: %w", name, err)
+	}
+	for _, status := range statuses {
+		if sameVexName(status.Name, name) {
+			id := status.ID
+			return &id, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown VEX status %q; use list_vex_statuses to see supported values", name)
+}
+
+func (s *Server) resolveVexJustificationID(ctx context.Context, args map[string]interface{}) (*string, error) {
+	if id := getStringPtrParam(args, "vex_justification_id"); id != nil && *id != "" {
+		return id, nil
+	}
+
+	name := strings.TrimSpace(stringParam(args, "vex_justification"))
+	if name == "" {
+		return nil, nil
+	}
+
+	justifications, err := s.client.GetVexJustifications(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve VEX justification %q: %w", name, err)
+	}
+	for _, justification := range justifications {
+		if sameVexName(justification.Name, name) {
+			id := justification.ID
+			return &id, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown VEX justification %q; use list_vex_justifications to see supported values", name)
+}
+
+func stringParam(args map[string]interface{}, key string) string {
+	val, ok := args[key].(string)
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+func sameVexName(left, right string) bool {
+	return normalizeVexName(left) == normalizeVexName(right)
+}
+
+func normalizeVexName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, " ", "_")
+	for strings.Contains(name, "__") {
+		name = strings.ReplaceAll(name, "__", "_")
+	}
+	return name
 }
 
 func getStringSlicePtrParam(args map[string]interface{}, key string) *[]string {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import "testing"
+
+func TestSameVexName_NormalizesCommonInputForms(t *testing.T) {
+	tests := []struct {
+		left  string
+		right string
+	}{
+		{left: "not_affected", right: "Not Affected"},
+		{left: "vulnerable_code_not_present", right: "vulnerable-code-not-present"},
+		{left: " fixed ", right: "fixed"},
+	}
+
+	for _, tt := range tests {
+		if !sameVexName(tt.left, tt.right) {
+			t.Fatalf("sameVexName(%q, %q) = false, want true", tt.left, tt.right)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add MCP tools to list VEX statuses and justifications with UUIDs
- allow update_component_vex to accept status and justification names and resolve them to UUIDs
- include VEX status/justification IDs in vulnerability list/search results

## Validation
- go test ./...