### PR TITLE
Add MCP tools for security incident workflows

### DIFF
--- a/internal/api/security_incidents.go
+++ b/internal/api/security_incidents.go
@@ -1,0 +1,566 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/interlynk-io/lynk-mcp/internal/graphql"
+)
+
+// SecurityIncident represents a supply-chain security incident.
+type SecurityIncident struct {
+	ID                 string
+	Title              string
+	Slug               string
+	Summary            string
+	Severity           string
+	Status             string
+	Confidence         string
+	RecommendedActions string
+	SourceURLs         string
+	FirstSeenAt        *time.Time
+	PublishedAt        *time.Time
+	LastUpdatedAt      *time.Time
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	Markers            []SecurityIncidentMarker
+	OrgImpactState     *OrganizationSecurityIncidentState
+}
+
+// SecurityIncidentMarker represents an incident indicator or affected component identity.
+type SecurityIncidentMarker struct {
+	ID               string
+	MarkerType       string
+	Purl             string
+	ComponentName    string
+	ComponentVersion string
+	GithubURL        string
+	Active           bool
+	AddedAt          time.Time
+	WithdrawnAt      *time.Time
+}
+
+// OrganizationSecurityIncidentState contains the current organization's impact rollup.
+type OrganizationSecurityIncidentState struct {
+	Status                  string
+	Severity                string
+	ImpactedProjectsCount   int
+	ImpactedVersionsCount   int
+	ImpactedComponentsCount int
+	LastEvaluatedAt         *time.Time
+	LastNotifiedAt          *time.Time
+}
+
+// ListSecurityIncidentsInput contains filters for listing incidents.
+type ListSecurityIncidentsInput struct {
+	Status []string
+}
+
+// CreateSecurityIncidentInput contains fields for creating an incident.
+type CreateSecurityIncidentInput struct {
+	Title              string
+	Severity           string
+	Confidence         *string
+	Summary            *string
+	RecommendedActions *string
+	SourceURLs         *string
+}
+
+// SecurityIncidentMarkerInput contains fields for creating a marker.
+type SecurityIncidentMarkerInput struct {
+	MarkerType       string `json:"markerType"`
+	Purl             string `json:"purl,omitempty"`
+	ComponentName    string `json:"componentName,omitempty"`
+	ComponentVersion string `json:"componentVersion,omitempty"`
+	GithubURL        string `json:"githubUrl,omitempty"`
+}
+
+// CreateSecurityIncidentResult contains the create mutation result.
+type CreateSecurityIncidentResult struct {
+	SecurityIncident *SecurityIncident
+	Errors           []string
+}
+
+// AddSecurityIncidentMarkersResult contains the marker mutation result.
+type AddSecurityIncidentMarkersResult struct {
+	Markers []SecurityIncidentMarker
+	Errors  []string
+}
+
+// SecurityIncidentMutationResult contains mutations that return an incident.
+type SecurityIncidentMutationResult struct {
+	SecurityIncident *SecurityIncident
+	Errors           []string
+}
+
+// DryRunSecurityIncidentImpactScanResult contains a dry-run scan queue result.
+type DryRunSecurityIncidentImpactScanResult struct {
+	Status string
+	Errors []string
+}
+
+// SecurityIncidentDryRunResultInput contains filters for reading dry-run results.
+type SecurityIncidentDryRunResultInput struct {
+	IncidentID string
+	OrgID      string
+	First      int
+	After      string
+}
+
+// SecurityIncidentDryRunResult contains dry-run scan status and optional org findings.
+type SecurityIncidentDryRunResult struct {
+	Status            string
+	Error             string
+	CompletedAt       *time.Time
+	TotalOrgsImpacted int
+	OrgResults        []SecurityIncidentDryRunOrgResult
+	Org               *SecurityIncidentDryRunOrg
+}
+
+// SecurityIncidentDryRunOrgResult contains per-organization dry-run rollup counts.
+type SecurityIncidentDryRunOrgResult struct {
+	OrganizationID          string
+	OrganizationName        string
+	ImpactedComponentsCount int
+	ImpactedProjectsCount   int
+	ImpactedVersionsCount   int
+}
+
+// SecurityIncidentDryRunOrg contains per-organization dry-run findings.
+type SecurityIncidentDryRunOrg struct {
+	SecurityIncidentDryRunOrgResult
+	Findings    []SecurityIncidentDryRunFinding
+	HasNextPage bool
+	EndCursor   string
+}
+
+// SecurityIncidentDryRunFinding represents a single dry-run component hit.
+type SecurityIncidentDryRunFinding struct {
+	ID                     string
+	OrganizationID         string
+	ProjectID              string
+	RootSbomID             string
+	ComponentSbomID        string
+	ComponentID            string
+	ComponentName          string
+	ComponentVersion       string
+	ComponentPurl          string
+	MarkerID               string
+	MarkerType             string
+	MarkerPurl             string
+	MarkerComponentName    string
+	MarkerComponentVersion string
+	MatchMethod            string
+	MatchedFields          map[string]interface{}
+	RootProjectName        string
+	RootProjectVersion     string
+	IsPartSbom             bool
+}
+
+type securityIncidentGraphQL struct {
+	ID                 string     `json:"id"`
+	Title              string     `json:"title"`
+	Slug               string     `json:"slug"`
+	Summary            string     `json:"summary"`
+	Severity           string     `json:"severity"`
+	Status             string     `json:"status"`
+	Confidence         string     `json:"confidence"`
+	RecommendedActions string     `json:"recommendedActions"`
+	SourceURLs         string     `json:"sourceUrls"`
+	FirstSeenAt        *time.Time `json:"firstSeenAt"`
+	PublishedAt        *time.Time `json:"publishedAt"`
+	LastUpdatedAt      *time.Time `json:"lastUpdatedAt"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	UpdatedAt          time.Time  `json:"updatedAt"`
+	Markers            []struct {
+		ID               string     `json:"id"`
+		MarkerType       string     `json:"markerType"`
+		Purl             string     `json:"purl"`
+		ComponentName    string     `json:"componentName"`
+		ComponentVersion string     `json:"componentVersion"`
+		GithubURL        string     `json:"githubUrl"`
+		Active           bool       `json:"active"`
+		AddedAt          time.Time  `json:"addedAt"`
+		WithdrawnAt      *time.Time `json:"withdrawnAt"`
+	} `json:"markers"`
+	OrgImpactState *struct {
+		Status                  string     `json:"status"`
+		Severity                string     `json:"severity"`
+		ImpactedProjectsCount   int        `json:"impactedProjectsCount"`
+		ImpactedVersionsCount   int        `json:"impactedVersionsCount"`
+		ImpactedComponentsCount int        `json:"impactedComponentsCount"`
+		LastEvaluatedAt         *time.Time `json:"lastEvaluatedAt"`
+		LastNotifiedAt          *time.Time `json:"lastNotifiedAt"`
+	} `json:"orgImpactState"`
+}
+
+// ListSecurityIncidents fetches incidents visible to the current organization.
+func (c *Client) ListSecurityIncidents(ctx context.Context, input ListSecurityIncidentsInput) ([]SecurityIncident, error) {
+	vars := make(map[string]interface{})
+	if len(input.Status) > 0 {
+		vars["status"] = input.Status
+	}
+
+	var result struct {
+		SecurityIncidents []securityIncidentGraphQL `json:"securityIncidents"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentsQuery, vars, &result); err != nil {
+		return nil, err
+	}
+
+	incidents := make([]SecurityIncident, len(result.SecurityIncidents))
+	for i, incident := range result.SecurityIncidents {
+		incidents[i] = mapSecurityIncident(incident)
+	}
+	return incidents, nil
+}
+
+// GetSecurityIncident fetches a single incident by ID.
+func (c *Client) GetSecurityIncident(ctx context.Context, id string) (*SecurityIncident, error) {
+	var result struct {
+		SecurityIncident *securityIncidentGraphQL `json:"securityIncident"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentQuery, map[string]interface{}{"id": id}, &result); err != nil {
+		return nil, err
+	}
+	if result.SecurityIncident == nil {
+		return nil, nil
+	}
+	incident := mapSecurityIncident(*result.SecurityIncident)
+	return &incident, nil
+}
+
+// CreateSecurityIncident creates a draft incident.
+func (c *Client) CreateSecurityIncident(ctx context.Context, input CreateSecurityIncidentInput) (*CreateSecurityIncidentResult, error) {
+	vars := map[string]interface{}{
+		"title":    input.Title,
+		"severity": input.Severity,
+	}
+	addStringVar(vars, "confidence", input.Confidence)
+	addStringVar(vars, "summary", input.Summary)
+	addStringVar(vars, "recommendedActions", input.RecommendedActions)
+	addStringVar(vars, "sourceUrls", input.SourceURLs)
+
+	var result struct {
+		CreateSecurityIncident struct {
+			SecurityIncident *securityIncidentGraphQL `json:"securityIncident"`
+			Errors           []string                 `json:"errors"`
+		} `json:"createSecurityIncident"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentCreateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.CreateSecurityIncident
+	createResult := &CreateSecurityIncidentResult{Errors: mutation.Errors}
+	if mutation.SecurityIncident != nil {
+		incident := mapSecurityIncident(*mutation.SecurityIncident)
+		createResult.SecurityIncident = &incident
+	}
+	return createResult, nil
+}
+
+// AddSecurityIncidentMarkers adds markers to an incident.
+func (c *Client) AddSecurityIncidentMarkers(ctx context.Context, incidentID string, markers []SecurityIncidentMarkerInput) (*AddSecurityIncidentMarkersResult, error) {
+	var result struct {
+		AddSecurityIncidentMarkers struct {
+			Markers []struct {
+				ID               string     `json:"id"`
+				MarkerType       string     `json:"markerType"`
+				Purl             string     `json:"purl"`
+				ComponentName    string     `json:"componentName"`
+				ComponentVersion string     `json:"componentVersion"`
+				GithubURL        string     `json:"githubUrl"`
+				Active           bool       `json:"active"`
+				AddedAt          time.Time  `json:"addedAt"`
+				WithdrawnAt      *time.Time `json:"withdrawnAt"`
+			} `json:"markers"`
+			Errors []string `json:"errors"`
+		} `json:"addSecurityIncidentMarkers"`
+	}
+
+	vars := map[string]interface{}{
+		"securityIncidentId": incidentID,
+		"markers":            markers,
+	}
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentAddMarkersMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.AddSecurityIncidentMarkers
+	mapped := make([]SecurityIncidentMarker, len(mutation.Markers))
+	for i, marker := range mutation.Markers {
+		mapped[i] = SecurityIncidentMarker{
+			ID:               marker.ID,
+			MarkerType:       marker.MarkerType,
+			Purl:             marker.Purl,
+			ComponentName:    marker.ComponentName,
+			ComponentVersion: marker.ComponentVersion,
+			GithubURL:        marker.GithubURL,
+			Active:           marker.Active,
+			AddedAt:          marker.AddedAt,
+			WithdrawnAt:      marker.WithdrawnAt,
+		}
+	}
+
+	return &AddSecurityIncidentMarkersResult{Markers: mapped, Errors: mutation.Errors}, nil
+}
+
+// PublishSecurityIncident publishes a draft incident and queues impact scanning.
+func (c *Client) PublishSecurityIncident(ctx context.Context, id string) (*SecurityIncidentMutationResult, error) {
+	return c.securityIncidentMutation(ctx, graphql.SecurityIncidentPublishMutation, "publishSecurityIncident", id)
+}
+
+// RerunSecurityIncidentImpactScan queues impact scanning for an active or resolved incident.
+func (c *Client) RerunSecurityIncidentImpactScan(ctx context.Context, id string) (*SecurityIncidentMutationResult, error) {
+	return c.securityIncidentMutation(ctx, graphql.SecurityIncidentRerunImpactScanMutation, "rerunSecurityIncidentImpactScan", id)
+}
+
+// DryRunSecurityIncidentImpactScan queues a dry-run impact scan.
+func (c *Client) DryRunSecurityIncidentImpactScan(ctx context.Context, id string) (*DryRunSecurityIncidentImpactScanResult, error) {
+	var result struct {
+		DryRunSecurityIncidentImpactScan struct {
+			Status string   `json:"status"`
+			Errors []string `json:"errors"`
+		} `json:"dryRunSecurityIncidentImpactScan"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentDryRunImpactScanMutation, map[string]interface{}{"id": id}, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.DryRunSecurityIncidentImpactScan
+	return &DryRunSecurityIncidentImpactScanResult{Status: mutation.Status, Errors: mutation.Errors}, nil
+}
+
+// GetSecurityIncidentDryRunResult fetches the latest dry-run scan result.
+func (c *Client) GetSecurityIncidentDryRunResult(ctx context.Context, input SecurityIncidentDryRunResultInput) (*SecurityIncidentDryRunResult, error) {
+	vars := map[string]interface{}{"incidentId": input.IncidentID}
+	query := graphql.SecurityIncidentDryRunResultQuery
+	if input.OrgID != "" {
+		query = graphql.SecurityIncidentDryRunOrgResultQuery
+		vars["orgId"] = input.OrgID
+		if input.First > 0 {
+			vars["first"] = input.First
+		} else {
+			vars["first"] = 50
+		}
+		if input.After != "" {
+			vars["after"] = input.After
+		}
+	}
+
+	var result struct {
+		SecurityIncidentDryRunResult dryRunResultGraphQL `json:"securityIncidentDryRunResult"`
+	}
+
+	if err := c.gql.Execute(ctx, query, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mapped := mapSecurityIncidentDryRunResult(result.SecurityIncidentDryRunResult)
+	return &mapped, nil
+}
+
+func (c *Client) securityIncidentMutation(ctx context.Context, query, fieldName, id string) (*SecurityIncidentMutationResult, error) {
+	var result map[string]struct {
+		SecurityIncident *securityIncidentGraphQL `json:"securityIncident"`
+		Errors           []string                 `json:"errors"`
+	}
+
+	if err := c.gql.Execute(ctx, query, map[string]interface{}{"id": id}, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result[fieldName]
+	mutationResult := &SecurityIncidentMutationResult{Errors: mutation.Errors}
+	if mutation.SecurityIncident != nil {
+		incident := mapSecurityIncident(*mutation.SecurityIncident)
+		mutationResult.SecurityIncident = &incident
+	}
+	return mutationResult, nil
+}
+
+type dryRunResultGraphQL struct {
+	Status            string                   `json:"status"`
+	Error             string                   `json:"error"`
+	CompletedAt       *time.Time               `json:"completedAt"`
+	TotalOrgsImpacted int                      `json:"totalOrgsImpacted"`
+	OrgResults        []dryRunOrgResultGraphQL `json:"orgResults"`
+	Org               *dryRunOrgGraphQL        `json:"org"`
+}
+
+type dryRunOrgResultGraphQL struct {
+	OrganizationID          string `json:"organizationId"`
+	OrganizationName        string `json:"organizationName"`
+	ImpactedComponentsCount int    `json:"impactedComponentsCount"`
+	ImpactedProjectsCount   int    `json:"impactedProjectsCount"`
+	ImpactedVersionsCount   int    `json:"impactedVersionsCount"`
+}
+
+type dryRunOrgGraphQL struct {
+	OrganizationID          string `json:"organizationId"`
+	OrganizationName        string `json:"organizationName"`
+	ImpactedComponentsCount int    `json:"impactedComponentsCount"`
+	ImpactedProjectsCount   int    `json:"impactedProjectsCount"`
+	ImpactedVersionsCount   int    `json:"impactedVersionsCount"`
+	Findings                struct {
+		Nodes []struct {
+			ID                     string                 `json:"id"`
+			OrganizationID         string                 `json:"organizationId"`
+			ProjectID              string                 `json:"projectId"`
+			RootSbomID             string                 `json:"rootSbomId"`
+			ComponentSbomID        string                 `json:"componentSbomId"`
+			ComponentID            string                 `json:"componentId"`
+			ComponentName          string                 `json:"componentName"`
+			ComponentVersion       string                 `json:"componentVersion"`
+			ComponentPurl          string                 `json:"componentPurl"`
+			MarkerID               string                 `json:"markerId"`
+			MarkerType             string                 `json:"markerType"`
+			MarkerPurl             string                 `json:"markerPurl"`
+			MarkerComponentName    string                 `json:"markerComponentName"`
+			MarkerComponentVersion string                 `json:"markerComponentVersion"`
+			MatchMethod            string                 `json:"matchMethod"`
+			MatchedFields          map[string]interface{} `json:"matchedFields"`
+			RootProjectName        string                 `json:"rootProjectName"`
+			RootProjectVersion     string                 `json:"rootProjectVersion"`
+			IsPartSbom             bool                   `json:"isPartSbom"`
+		} `json:"nodes"`
+		PageInfo struct {
+			HasNextPage bool   `json:"hasNextPage"`
+			EndCursor   string `json:"endCursor"`
+		} `json:"pageInfo"`
+	} `json:"findings"`
+}
+
+func mapSecurityIncident(input securityIncidentGraphQL) SecurityIncident {
+	markers := make([]SecurityIncidentMarker, len(input.Markers))
+	for i, marker := range input.Markers {
+		markers[i] = SecurityIncidentMarker{
+			ID:               marker.ID,
+			MarkerType:       marker.MarkerType,
+			Purl:             marker.Purl,
+			ComponentName:    marker.ComponentName,
+			ComponentVersion: marker.ComponentVersion,
+			GithubURL:        marker.GithubURL,
+			Active:           marker.Active,
+			AddedAt:          marker.AddedAt,
+			WithdrawnAt:      marker.WithdrawnAt,
+		}
+	}
+
+	var orgImpactState *OrganizationSecurityIncidentState
+	if input.OrgImpactState != nil {
+		orgImpactState = &OrganizationSecurityIncidentState{
+			Status:                  input.OrgImpactState.Status,
+			Severity:                input.OrgImpactState.Severity,
+			ImpactedProjectsCount:   input.OrgImpactState.ImpactedProjectsCount,
+			ImpactedVersionsCount:   input.OrgImpactState.ImpactedVersionsCount,
+			ImpactedComponentsCount: input.OrgImpactState.ImpactedComponentsCount,
+			LastEvaluatedAt:         input.OrgImpactState.LastEvaluatedAt,
+			LastNotifiedAt:          input.OrgImpactState.LastNotifiedAt,
+		}
+	}
+
+	return SecurityIncident{
+		ID:                 input.ID,
+		Title:              input.Title,
+		Slug:               input.Slug,
+		Summary:            input.Summary,
+		Severity:           input.Severity,
+		Status:             input.Status,
+		Confidence:         input.Confidence,
+		RecommendedActions: input.RecommendedActions,
+		SourceURLs:         input.SourceURLs,
+		FirstSeenAt:        input.FirstSeenAt,
+		PublishedAt:        input.PublishedAt,
+		LastUpdatedAt:      input.LastUpdatedAt,
+		CreatedAt:          input.CreatedAt,
+		UpdatedAt:          input.UpdatedAt,
+		Markers:            markers,
+		OrgImpactState:     orgImpactState,
+	}
+}
+
+func mapSecurityIncidentDryRunResult(input dryRunResultGraphQL) SecurityIncidentDryRunResult {
+	orgResults := make([]SecurityIncidentDryRunOrgResult, len(input.OrgResults))
+	for i, orgResult := range input.OrgResults {
+		orgResults[i] = mapSecurityIncidentDryRunOrgResult(orgResult)
+	}
+
+	var org *SecurityIncidentDryRunOrg
+	if input.Org != nil {
+		findings := make([]SecurityIncidentDryRunFinding, len(input.Org.Findings.Nodes))
+		for i, finding := range input.Org.Findings.Nodes {
+			findings[i] = SecurityIncidentDryRunFinding{
+				ID:                     finding.ID,
+				OrganizationID:         finding.OrganizationID,
+				ProjectID:              finding.ProjectID,
+				RootSbomID:             finding.RootSbomID,
+				ComponentSbomID:        finding.ComponentSbomID,
+				ComponentID:            finding.ComponentID,
+				ComponentName:          finding.ComponentName,
+				ComponentVersion:       finding.ComponentVersion,
+				ComponentPurl:          finding.ComponentPurl,
+				MarkerID:               finding.MarkerID,
+				MarkerType:             finding.MarkerType,
+				MarkerPurl:             finding.MarkerPurl,
+				MarkerComponentName:    finding.MarkerComponentName,
+				MarkerComponentVersion: finding.MarkerComponentVersion,
+				MatchMethod:            finding.MatchMethod,
+				MatchedFields:          finding.MatchedFields,
+				RootProjectName:        finding.RootProjectName,
+				RootProjectVersion:     finding.RootProjectVersion,
+				IsPartSbom:             finding.IsPartSbom,
+			}
+		}
+		org = &SecurityIncidentDryRunOrg{
+			SecurityIncidentDryRunOrgResult: SecurityIncidentDryRunOrgResult{
+				OrganizationID:          input.Org.OrganizationID,
+				OrganizationName:        input.Org.OrganizationName,
+				ImpactedComponentsCount: input.Org.ImpactedComponentsCount,
+				ImpactedProjectsCount:   input.Org.ImpactedProjectsCount,
+				ImpactedVersionsCount:   input.Org.ImpactedVersionsCount,
+			},
+			Findings:    findings,
+			HasNextPage: input.Org.Findings.PageInfo.HasNextPage,
+			EndCursor:   input.Org.Findings.PageInfo.EndCursor,
+		}
+	}
+
+	return SecurityIncidentDryRunResult{
+		Status:            input.Status,
+		Error:             input.Error,
+		CompletedAt:       input.CompletedAt,
+		TotalOrgsImpacted: input.TotalOrgsImpacted,
+		OrgResults:        orgResults,
+		Org:               org,
+	}
+}
+
+func mapSecurityIncidentDryRunOrgResult(input dryRunOrgResultGraphQL) SecurityIncidentDryRunOrgResult {
+	return SecurityIncidentDryRunOrgResult{
+		OrganizationID:          input.OrganizationID,
+		OrganizationName:        input.OrganizationName,
+		ImpactedComponentsCount: input.ImpactedComponentsCount,
+		ImpactedProjectsCount:   input.ImpactedProjectsCount,
+		ImpactedVersionsCount:   input.ImpactedVersionsCount,
+	}
+}

--- a/internal/api/security_incidents.go
+++ b/internal/api/security_incidents.go
@@ -220,13 +220,6 @@ type SuppressSecurityIncidentFindingResult struct {
 	Errors  []string
 }
 
-// SecurityIncidentEnabledOrganization represents an organization with incident scans enabled.
-type SecurityIncidentEnabledOrganization struct {
-	ID                       string
-	Name                     string
-	SecurityIncidentsEnabled bool
-}
-
 // DryRunSecurityIncidentImpactScanResult contains a dry-run scan queue result.
 type DryRunSecurityIncidentImpactScanResult struct {
 	Status string
@@ -665,31 +658,6 @@ func (c *Client) GetSecurityIncidentDryRunResult(ctx context.Context, input Secu
 
 	mapped := mapSecurityIncidentDryRunResult(result.SecurityIncidentDryRunResult)
 	return &mapped, nil
-}
-
-// SecurityIncidentEnabledOrganizations lists organizations with incident scans enabled.
-func (c *Client) SecurityIncidentEnabledOrganizations(ctx context.Context) ([]SecurityIncidentEnabledOrganization, error) {
-	var result struct {
-		Organizations []struct {
-			ID                       string `json:"id"`
-			Name                     string `json:"name"`
-			SecurityIncidentsEnabled bool   `json:"securityIncidentsEnabled"`
-		} `json:"securityIncidentEnabledOrganizations"`
-	}
-
-	if err := c.gql.Execute(ctx, graphql.SecurityIncidentEnabledOrganizationsQuery, nil, &result); err != nil {
-		return nil, err
-	}
-
-	organizations := make([]SecurityIncidentEnabledOrganization, len(result.Organizations))
-	for i, org := range result.Organizations {
-		organizations[i] = SecurityIncidentEnabledOrganization{
-			ID:                       org.ID,
-			Name:                     org.Name,
-			SecurityIncidentsEnabled: org.SecurityIncidentsEnabled,
-		}
-	}
-	return organizations, nil
 }
 
 func (c *Client) securityIncidentMutation(ctx context.Context, query, fieldName, id string) (*SecurityIncidentMutationResult, error) {

--- a/internal/api/security_incidents.go
+++ b/internal/api/security_incidents.go
@@ -80,6 +80,17 @@ type CreateSecurityIncidentInput struct {
 	SourceURLs         *string
 }
 
+// UpdateSecurityIncidentInput contains editable incident fields.
+type UpdateSecurityIncidentInput struct {
+	ID                 string
+	Title              *string
+	Severity           *string
+	Confidence         *string
+	Summary            *string
+	RecommendedActions *string
+	SourceURLs         *string
+}
+
 // SecurityIncidentMarkerInput contains fields for creating a marker.
 type SecurityIncidentMarkerInput struct {
 	MarkerType       string `json:"markerType"`
@@ -87,6 +98,28 @@ type SecurityIncidentMarkerInput struct {
 	ComponentName    string `json:"componentName,omitempty"`
 	ComponentVersion string `json:"componentVersion,omitempty"`
 	GithubURL        string `json:"githubUrl,omitempty"`
+}
+
+// CreateSecurityIncidentUpdateInput contains fields for adding an incident timeline update.
+type CreateSecurityIncidentUpdateInput struct {
+	SecurityIncidentID string
+	Title              string
+	UpdateType         string
+	OccurredAt         string
+	Body               *string
+	CustomerVisible    *bool
+}
+
+// SecurityIncidentFindingsInput contains filters for incident findings.
+type SecurityIncidentFindingsInput struct {
+	IncidentID string
+	Statuses   []string
+}
+
+// SuppressSecurityIncidentFindingInput contains fields for suppressing a finding.
+type SuppressSecurityIncidentFindingInput struct {
+	FindingID string
+	Reason    string
 }
 
 // CreateSecurityIncidentResult contains the create mutation result.
@@ -101,10 +134,97 @@ type AddSecurityIncidentMarkersResult struct {
 	Errors  []string
 }
 
+// SecurityIncidentMarkersResult contains marker mutations.
+type SecurityIncidentMarkersResult struct {
+	Markers []SecurityIncidentMarker
+	Errors  []string
+}
+
 // SecurityIncidentMutationResult contains mutations that return an incident.
 type SecurityIncidentMutationResult struct {
 	SecurityIncident *SecurityIncident
 	Errors           []string
+}
+
+// SecurityIncidentUpdate represents a timeline update for an incident.
+type SecurityIncidentUpdate struct {
+	Title      string
+	UpdateType string
+	Body       string
+	OccurredAt *time.Time
+}
+
+// CreateSecurityIncidentUpdateResult contains the timeline update mutation result.
+type CreateSecurityIncidentUpdateResult struct {
+	Update *SecurityIncidentUpdate
+	Errors []string
+}
+
+// SecurityIncidentFinding represents a customer-facing incident finding.
+type SecurityIncidentFinding struct {
+	ID              string
+	Status          string
+	MatchMethod     string
+	MatchedFields   map[string]interface{}
+	FirstDetectedAt time.Time
+	LastConfirmedAt *time.Time
+	IsPartSbom      bool
+	Component       *SecurityIncidentFindingComponent
+	RootSbom        *SecurityIncidentFindingSbom
+}
+
+// SecurityIncidentFindingComponent contains the affected component in a finding.
+type SecurityIncidentFindingComponent struct {
+	ID          string
+	Name        string
+	Version     string
+	Kind        string
+	Purl        string
+	Cpes        []string
+	LicensesExp string
+	Group       string
+	Primary     bool
+	Internal    bool
+	SbomID      string
+	UpdatedAt   time.Time
+	Sbom        *SecurityIncidentFindingSbom
+}
+
+// SecurityIncidentFindingSbom contains root/component SBOM context for a finding.
+type SecurityIncidentFindingSbom struct {
+	ID             string
+	ProjectVersion string
+	Project        *SecurityIncidentFindingProject
+}
+
+// SecurityIncidentFindingProject contains project context for a finding.
+type SecurityIncidentFindingProject struct {
+	ID             string
+	Name           string
+	ProjectGroupID string
+}
+
+// SecurityIncidentFindingsResult contains findings for one incident.
+type SecurityIncidentFindingsResult struct {
+	IncidentID string
+	Title      string
+	Slug       string
+	Status     string
+	Severity   string
+	Findings   []SecurityIncidentFinding
+}
+
+// SuppressSecurityIncidentFindingResult contains the suppression mutation result.
+type SuppressSecurityIncidentFindingResult struct {
+	Finding *SecurityIncidentFinding
+	Errors  []string
+}
+
+// SecurityIncidentEnabledOrganization represents an organization with incident scans enabled.
+type SecurityIncidentEnabledOrganization struct {
+	ID                       string
+	Name                     string
+	SecurityIncidentsEnabled bool
 }
 
 // DryRunSecurityIncidentImpactScanResult contains a dry-run scan queue result.
@@ -172,32 +292,22 @@ type SecurityIncidentDryRunFinding struct {
 }
 
 type securityIncidentGraphQL struct {
-	ID                 string     `json:"id"`
-	Title              string     `json:"title"`
-	Slug               string     `json:"slug"`
-	Summary            string     `json:"summary"`
-	Severity           string     `json:"severity"`
-	Status             string     `json:"status"`
-	Confidence         string     `json:"confidence"`
-	RecommendedActions string     `json:"recommendedActions"`
-	SourceURLs         string     `json:"sourceUrls"`
-	FirstSeenAt        *time.Time `json:"firstSeenAt"`
-	PublishedAt        *time.Time `json:"publishedAt"`
-	LastUpdatedAt      *time.Time `json:"lastUpdatedAt"`
-	CreatedAt          time.Time  `json:"createdAt"`
-	UpdatedAt          time.Time  `json:"updatedAt"`
-	Markers            []struct {
-		ID               string     `json:"id"`
-		MarkerType       string     `json:"markerType"`
-		Purl             string     `json:"purl"`
-		ComponentName    string     `json:"componentName"`
-		ComponentVersion string     `json:"componentVersion"`
-		GithubURL        string     `json:"githubUrl"`
-		Active           bool       `json:"active"`
-		AddedAt          time.Time  `json:"addedAt"`
-		WithdrawnAt      *time.Time `json:"withdrawnAt"`
-	} `json:"markers"`
-	OrgImpactState *struct {
+	ID                 string                          `json:"id"`
+	Title              string                          `json:"title"`
+	Slug               string                          `json:"slug"`
+	Summary            string                          `json:"summary"`
+	Severity           string                          `json:"severity"`
+	Status             string                          `json:"status"`
+	Confidence         string                          `json:"confidence"`
+	RecommendedActions string                          `json:"recommendedActions"`
+	SourceURLs         string                          `json:"sourceUrls"`
+	FirstSeenAt        *time.Time                      `json:"firstSeenAt"`
+	PublishedAt        *time.Time                      `json:"publishedAt"`
+	LastUpdatedAt      *time.Time                      `json:"lastUpdatedAt"`
+	CreatedAt          time.Time                       `json:"createdAt"`
+	UpdatedAt          time.Time                       `json:"updatedAt"`
+	Markers            []securityIncidentMarkerGraphQL `json:"markers"`
+	OrgImpactState     *struct {
 		Status                  string     `json:"status"`
 		Severity                string     `json:"severity"`
 		ImpactedProjectsCount   int        `json:"impactedProjectsCount"`
@@ -206,6 +316,63 @@ type securityIncidentGraphQL struct {
 		LastEvaluatedAt         *time.Time `json:"lastEvaluatedAt"`
 		LastNotifiedAt          *time.Time `json:"lastNotifiedAt"`
 	} `json:"orgImpactState"`
+}
+
+type securityIncidentMarkerGraphQL struct {
+	ID               string     `json:"id"`
+	MarkerType       string     `json:"markerType"`
+	Purl             string     `json:"purl"`
+	ComponentName    string     `json:"componentName"`
+	ComponentVersion string     `json:"componentVersion"`
+	GithubURL        string     `json:"githubUrl"`
+	Active           bool       `json:"active"`
+	AddedAt          time.Time  `json:"addedAt"`
+	WithdrawnAt      *time.Time `json:"withdrawnAt"`
+}
+
+type securityIncidentUpdateGraphQL struct {
+	Title      string     `json:"title"`
+	UpdateType string     `json:"updateType"`
+	Body       string     `json:"body"`
+	OccurredAt *time.Time `json:"occurredAt"`
+}
+
+type securityIncidentFindingGraphQL struct {
+	ID              string                 `json:"id"`
+	Status          string                 `json:"status"`
+	MatchMethod     string                 `json:"matchMethod"`
+	MatchedFields   map[string]interface{} `json:"matchedFields"`
+	FirstDetectedAt time.Time              `json:"firstDetectedAt"`
+	LastConfirmedAt *time.Time             `json:"lastConfirmedAt"`
+	IsPartSbom      bool                   `json:"isPartSbom"`
+	Component       *struct {
+		ID          string          `json:"id"`
+		Name        string          `json:"name"`
+		Version     string          `json:"version"`
+		Kind        string          `json:"kind"`
+		Purl        string          `json:"purl"`
+		Cpes        []string        `json:"cpes"`
+		LicensesExp string          `json:"licensesExp"`
+		Group       string          `json:"group"`
+		Primary     bool            `json:"primary"`
+		Internal    bool            `json:"internal"`
+		SbomID      string          `json:"sbomId"`
+		UpdatedAt   time.Time       `json:"updatedAt"`
+		Sbom        *sbomRefGraphQL `json:"sbom"`
+	} `json:"component"`
+	RootSbom *sbomRefGraphQL `json:"rootSbom"`
+}
+
+type sbomRefGraphQL struct {
+	ID             string             `json:"id"`
+	ProjectVersion string             `json:"projectVersion"`
+	Project        *projectRefGraphQL `json:"project"`
+}
+
+type projectRefGraphQL struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	ProjectGroupID string `json:"projectGroupId"`
 }
 
 // ListSecurityIncidents fetches incidents visible to the current organization.
@@ -277,22 +444,65 @@ func (c *Client) CreateSecurityIncident(ctx context.Context, input CreateSecurit
 	return createResult, nil
 }
 
+// UpdateSecurityIncident updates editable incident fields.
+func (c *Client) UpdateSecurityIncident(ctx context.Context, input UpdateSecurityIncidentInput) (*SecurityIncidentMutationResult, error) {
+	vars := map[string]interface{}{"id": input.ID}
+	addStringVar(vars, "title", input.Title)
+	addStringVar(vars, "severity", input.Severity)
+	addStringVar(vars, "confidence", input.Confidence)
+	addStringVar(vars, "summary", input.Summary)
+	addStringVar(vars, "recommendedActions", input.RecommendedActions)
+	addStringVar(vars, "sourceUrls", input.SourceURLs)
+
+	return c.securityIncidentMutationWithVars(ctx, graphql.SecurityIncidentUpdateMutation, "updateSecurityIncident", vars)
+}
+
+// GetSecurityIncidentFindings fetches customer-facing findings for the current organization.
+func (c *Client) GetSecurityIncidentFindings(ctx context.Context, input SecurityIncidentFindingsInput) (*SecurityIncidentFindingsResult, error) {
+	vars := map[string]interface{}{"id": input.IncidentID}
+	if len(input.Statuses) > 0 {
+		vars["statuses"] = input.Statuses
+	}
+
+	var result struct {
+		SecurityIncident *struct {
+			ID       string                           `json:"id"`
+			Title    string                           `json:"title"`
+			Slug     string                           `json:"slug"`
+			Status   string                           `json:"status"`
+			Severity string                           `json:"severity"`
+			Findings []securityIncidentFindingGraphQL `json:"findings"`
+		} `json:"securityIncident"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentFindingsQuery, vars, &result); err != nil {
+		return nil, err
+	}
+	if result.SecurityIncident == nil {
+		return nil, nil
+	}
+
+	findings := make([]SecurityIncidentFinding, len(result.SecurityIncident.Findings))
+	for i, finding := range result.SecurityIncident.Findings {
+		findings[i] = mapSecurityIncidentFinding(finding)
+	}
+
+	return &SecurityIncidentFindingsResult{
+		IncidentID: result.SecurityIncident.ID,
+		Title:      result.SecurityIncident.Title,
+		Slug:       result.SecurityIncident.Slug,
+		Status:     result.SecurityIncident.Status,
+		Severity:   result.SecurityIncident.Severity,
+		Findings:   findings,
+	}, nil
+}
+
 // AddSecurityIncidentMarkers adds markers to an incident.
 func (c *Client) AddSecurityIncidentMarkers(ctx context.Context, incidentID string, markers []SecurityIncidentMarkerInput) (*AddSecurityIncidentMarkersResult, error) {
 	var result struct {
 		AddSecurityIncidentMarkers struct {
-			Markers []struct {
-				ID               string     `json:"id"`
-				MarkerType       string     `json:"markerType"`
-				Purl             string     `json:"purl"`
-				ComponentName    string     `json:"componentName"`
-				ComponentVersion string     `json:"componentVersion"`
-				GithubURL        string     `json:"githubUrl"`
-				Active           bool       `json:"active"`
-				AddedAt          time.Time  `json:"addedAt"`
-				WithdrawnAt      *time.Time `json:"withdrawnAt"`
-			} `json:"markers"`
-			Errors []string `json:"errors"`
+			Markers []securityIncidentMarkerGraphQL `json:"markers"`
+			Errors  []string                        `json:"errors"`
 		} `json:"addSecurityIncidentMarkers"`
 	}
 
@@ -305,27 +515,105 @@ func (c *Client) AddSecurityIncidentMarkers(ctx context.Context, incidentID stri
 	}
 
 	mutation := result.AddSecurityIncidentMarkers
-	mapped := make([]SecurityIncidentMarker, len(mutation.Markers))
-	for i, marker := range mutation.Markers {
-		mapped[i] = SecurityIncidentMarker{
-			ID:               marker.ID,
-			MarkerType:       marker.MarkerType,
-			Purl:             marker.Purl,
-			ComponentName:    marker.ComponentName,
-			ComponentVersion: marker.ComponentVersion,
-			GithubURL:        marker.GithubURL,
-			Active:           marker.Active,
-			AddedAt:          marker.AddedAt,
-			WithdrawnAt:      marker.WithdrawnAt,
-		}
-	}
+	mapped := mapSecurityIncidentMarkers(mutation.Markers)
 
 	return &AddSecurityIncidentMarkersResult{Markers: mapped, Errors: mutation.Errors}, nil
+}
+
+// WithdrawSecurityIncidentMarkers withdraws active markers from an incident.
+func (c *Client) WithdrawSecurityIncidentMarkers(ctx context.Context, incidentID string, markerIDs []string) (*SecurityIncidentMarkersResult, error) {
+	var result struct {
+		WithdrawSecurityIncidentMarkers struct {
+			Markers []securityIncidentMarkerGraphQL `json:"markers"`
+			Errors  []string                        `json:"errors"`
+		} `json:"withdrawSecurityIncidentMarkers"`
+	}
+
+	vars := map[string]interface{}{
+		"securityIncidentId": incidentID,
+		"markerIds":          markerIDs,
+	}
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentWithdrawMarkersMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.WithdrawSecurityIncidentMarkers
+	return &SecurityIncidentMarkersResult{
+		Markers: mapSecurityIncidentMarkers(mutation.Markers),
+		Errors:  mutation.Errors,
+	}, nil
 }
 
 // PublishSecurityIncident publishes a draft incident and queues impact scanning.
 func (c *Client) PublishSecurityIncident(ctx context.Context, id string) (*SecurityIncidentMutationResult, error) {
 	return c.securityIncidentMutation(ctx, graphql.SecurityIncidentPublishMutation, "publishSecurityIncident", id)
+}
+
+// ResolveSecurityIncident resolves an active incident.
+func (c *Client) ResolveSecurityIncident(ctx context.Context, id string) (*SecurityIncidentMutationResult, error) {
+	return c.securityIncidentMutation(ctx, graphql.SecurityIncidentResolveMutation, "resolveSecurityIncident", id)
+}
+
+// ArchiveSecurityIncident archives an incident.
+func (c *Client) ArchiveSecurityIncident(ctx context.Context, id string) (*SecurityIncidentMutationResult, error) {
+	return c.securityIncidentMutation(ctx, graphql.SecurityIncidentArchiveMutation, "archiveSecurityIncident", id)
+}
+
+// CreateSecurityIncidentUpdate adds a timeline update to an incident.
+func (c *Client) CreateSecurityIncidentUpdate(ctx context.Context, input CreateSecurityIncidentUpdateInput) (*CreateSecurityIncidentUpdateResult, error) {
+	vars := map[string]interface{}{
+		"securityIncidentId": input.SecurityIncidentID,
+		"title":              input.Title,
+		"updateType":         input.UpdateType,
+		"occurredAt":         input.OccurredAt,
+	}
+	addStringVar(vars, "body", input.Body)
+	addBoolVar(vars, "customerVisible", input.CustomerVisible)
+
+	var result struct {
+		CreateSecurityIncidentUpdate struct {
+			Update *securityIncidentUpdateGraphQL `json:"securityIncidentUpdate"`
+			Errors []string                       `json:"errors"`
+		} `json:"createSecurityIncidentUpdate"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentCreateUpdateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.CreateSecurityIncidentUpdate
+	updateResult := &CreateSecurityIncidentUpdateResult{Errors: mutation.Errors}
+	if mutation.Update != nil {
+		update := mapSecurityIncidentUpdate(*mutation.Update)
+		updateResult.Update = &update
+	}
+	return updateResult, nil
+}
+
+// SuppressSecurityIncidentFinding suppresses a finding for the current organization.
+func (c *Client) SuppressSecurityIncidentFinding(ctx context.Context, input SuppressSecurityIncidentFindingInput) (*SuppressSecurityIncidentFindingResult, error) {
+	var result struct {
+		SuppressSecurityIncidentFinding struct {
+			Finding *securityIncidentFindingGraphQL `json:"finding"`
+			Errors  []string                        `json:"errors"`
+		} `json:"suppressSecurityIncidentFinding"`
+	}
+
+	vars := map[string]interface{}{
+		"findingId": input.FindingID,
+		"reason":    input.Reason,
+	}
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentSuppressFindingMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.SuppressSecurityIncidentFinding
+	suppressResult := &SuppressSecurityIncidentFindingResult{Errors: mutation.Errors}
+	if mutation.Finding != nil {
+		finding := mapSecurityIncidentFinding(*mutation.Finding)
+		suppressResult.Finding = &finding
+	}
+	return suppressResult, nil
 }
 
 // RerunSecurityIncidentImpactScan queues impact scanning for an active or resolved incident.
@@ -379,13 +667,42 @@ func (c *Client) GetSecurityIncidentDryRunResult(ctx context.Context, input Secu
 	return &mapped, nil
 }
 
+// SecurityIncidentEnabledOrganizations lists organizations with incident scans enabled.
+func (c *Client) SecurityIncidentEnabledOrganizations(ctx context.Context) ([]SecurityIncidentEnabledOrganization, error) {
+	var result struct {
+		Organizations []struct {
+			ID                       string `json:"id"`
+			Name                     string `json:"name"`
+			SecurityIncidentsEnabled bool   `json:"securityIncidentsEnabled"`
+		} `json:"securityIncidentEnabledOrganizations"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SecurityIncidentEnabledOrganizationsQuery, nil, &result); err != nil {
+		return nil, err
+	}
+
+	organizations := make([]SecurityIncidentEnabledOrganization, len(result.Organizations))
+	for i, org := range result.Organizations {
+		organizations[i] = SecurityIncidentEnabledOrganization{
+			ID:                       org.ID,
+			Name:                     org.Name,
+			SecurityIncidentsEnabled: org.SecurityIncidentsEnabled,
+		}
+	}
+	return organizations, nil
+}
+
 func (c *Client) securityIncidentMutation(ctx context.Context, query, fieldName, id string) (*SecurityIncidentMutationResult, error) {
+	return c.securityIncidentMutationWithVars(ctx, query, fieldName, map[string]interface{}{"id": id})
+}
+
+func (c *Client) securityIncidentMutationWithVars(ctx context.Context, query, fieldName string, vars map[string]interface{}) (*SecurityIncidentMutationResult, error) {
 	var result map[string]struct {
 		SecurityIncident *securityIncidentGraphQL `json:"securityIncident"`
 		Errors           []string                 `json:"errors"`
 	}
 
-	if err := c.gql.Execute(ctx, query, map[string]interface{}{"id": id}, &result); err != nil {
+	if err := c.gql.Execute(ctx, query, vars, &result); err != nil {
 		return nil, err
 	}
 
@@ -451,20 +768,7 @@ type dryRunOrgGraphQL struct {
 }
 
 func mapSecurityIncident(input securityIncidentGraphQL) SecurityIncident {
-	markers := make([]SecurityIncidentMarker, len(input.Markers))
-	for i, marker := range input.Markers {
-		markers[i] = SecurityIncidentMarker{
-			ID:               marker.ID,
-			MarkerType:       marker.MarkerType,
-			Purl:             marker.Purl,
-			ComponentName:    marker.ComponentName,
-			ComponentVersion: marker.ComponentVersion,
-			GithubURL:        marker.GithubURL,
-			Active:           marker.Active,
-			AddedAt:          marker.AddedAt,
-			WithdrawnAt:      marker.WithdrawnAt,
-		}
-	}
+	markers := mapSecurityIncidentMarkers(input.Markers)
 
 	var orgImpactState *OrganizationSecurityIncidentState
 	if input.OrgImpactState != nil {
@@ -496,6 +800,88 @@ func mapSecurityIncident(input securityIncidentGraphQL) SecurityIncident {
 		UpdatedAt:          input.UpdatedAt,
 		Markers:            markers,
 		OrgImpactState:     orgImpactState,
+	}
+}
+
+func mapSecurityIncidentMarkers(input []securityIncidentMarkerGraphQL) []SecurityIncidentMarker {
+	markers := make([]SecurityIncidentMarker, len(input))
+	for i, marker := range input {
+		markers[i] = SecurityIncidentMarker{
+			ID:               marker.ID,
+			MarkerType:       marker.MarkerType,
+			Purl:             marker.Purl,
+			ComponentName:    marker.ComponentName,
+			ComponentVersion: marker.ComponentVersion,
+			GithubURL:        marker.GithubURL,
+			Active:           marker.Active,
+			AddedAt:          marker.AddedAt,
+			WithdrawnAt:      marker.WithdrawnAt,
+		}
+	}
+	return markers
+}
+
+func mapSecurityIncidentUpdate(input securityIncidentUpdateGraphQL) SecurityIncidentUpdate {
+	return SecurityIncidentUpdate{
+		Title:      input.Title,
+		UpdateType: input.UpdateType,
+		Body:       input.Body,
+		OccurredAt: input.OccurredAt,
+	}
+}
+
+func mapSecurityIncidentFinding(input securityIncidentFindingGraphQL) SecurityIncidentFinding {
+	finding := SecurityIncidentFinding{
+		ID:              input.ID,
+		Status:          input.Status,
+		MatchMethod:     input.MatchMethod,
+		MatchedFields:   input.MatchedFields,
+		FirstDetectedAt: input.FirstDetectedAt,
+		LastConfirmedAt: input.LastConfirmedAt,
+		IsPartSbom:      input.IsPartSbom,
+		RootSbom:        mapSecurityIncidentFindingSbom(input.RootSbom),
+	}
+
+	if input.Component != nil {
+		finding.Component = &SecurityIncidentFindingComponent{
+			ID:          input.Component.ID,
+			Name:        input.Component.Name,
+			Version:     input.Component.Version,
+			Kind:        input.Component.Kind,
+			Purl:        input.Component.Purl,
+			Cpes:        input.Component.Cpes,
+			LicensesExp: input.Component.LicensesExp,
+			Group:       input.Component.Group,
+			Primary:     input.Component.Primary,
+			Internal:    input.Component.Internal,
+			SbomID:      input.Component.SbomID,
+			UpdatedAt:   input.Component.UpdatedAt,
+			Sbom:        mapSecurityIncidentFindingSbom(input.Component.Sbom),
+		}
+	}
+
+	return finding
+}
+
+func mapSecurityIncidentFindingSbom(input *sbomRefGraphQL) *SecurityIncidentFindingSbom {
+	if input == nil {
+		return nil
+	}
+	return &SecurityIncidentFindingSbom{
+		ID:             input.ID,
+		ProjectVersion: input.ProjectVersion,
+		Project:        mapSecurityIncidentFindingProject(input.Project),
+	}
+}
+
+func mapSecurityIncidentFindingProject(input *projectRefGraphQL) *SecurityIncidentFindingProject {
+	if input == nil {
+		return nil
+	}
+	return &SecurityIncidentFindingProject{
+		ID:             input.ID,
+		Name:           input.Name,
+		ProjectGroupID: input.ProjectGroupID,
 	}
 }
 

--- a/internal/api/security_incidents_test.go
+++ b/internal/api/security_incidents_test.go
@@ -1,0 +1,331 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpdateSecurityIncident_MapsInputsAndResult(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"updateSecurityIncident": {
+					"securityIncident": {
+						"id": "incident-1",
+						"title": "Updated incident",
+						"slug": "updated-incident",
+						"summary": "",
+						"severity": "critical",
+						"status": "active",
+						"confidence": "confirmed",
+						"recommendedActions": "Rotate tokens",
+						"sourceUrls": "",
+						"createdAt": "2026-05-01T00:00:00Z",
+						"updatedAt": "2026-05-02T00:00:00Z",
+						"markers": []
+					},
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	summary := ""
+	recommendedActions := "Rotate tokens"
+	result, err := client.UpdateSecurityIncident(context.Background(), UpdateSecurityIncidentInput{
+		ID:                 "incident-1",
+		Summary:            &summary,
+		RecommendedActions: &recommendedActions,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSecurityIncident returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["id"] != "incident-1" {
+		t.Fatalf("id = %#v, want incident-1", request["id"])
+	}
+	if request["summary"] != "" {
+		t.Fatalf("summary = %#v, want empty string", request["summary"])
+	}
+	if request["recommendedActions"] != "Rotate tokens" {
+		t.Fatalf("recommendedActions = %#v, want Rotate tokens", request["recommendedActions"])
+	}
+
+	if result.SecurityIncident == nil {
+		t.Fatal("expected updated security incident")
+	}
+	if result.SecurityIncident.ID != "incident-1" || result.SecurityIncident.RecommendedActions != "Rotate tokens" {
+		t.Fatalf("unexpected incident: %#v", result.SecurityIncident)
+	}
+}
+
+func TestWithdrawSecurityIncidentMarkers_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"withdrawSecurityIncidentMarkers": {
+					"markers": [
+						{
+							"id": "marker-1",
+							"markerType": "purl",
+							"purl": "pkg:npm/example@1.0.0",
+							"componentName": "",
+							"componentVersion": "",
+							"githubUrl": "",
+							"active": false,
+							"addedAt": "2026-05-01T00:00:00Z",
+							"withdrawnAt": "2026-05-03T00:00:00Z"
+						}
+					],
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.WithdrawSecurityIncidentMarkers(
+		context.Background(),
+		"incident-1",
+		[]string{"marker-1"},
+	)
+	if err != nil {
+		t.Fatalf("WithdrawSecurityIncidentMarkers returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["securityIncidentId"] != "incident-1" {
+		t.Fatalf("securityIncidentId = %#v, want incident-1", request["securityIncidentId"])
+	}
+	markerIDs := request["markerIds"].([]string)
+	if len(markerIDs) != 1 || markerIDs[0] != "marker-1" {
+		t.Fatalf("markerIds = %#v, want marker-1", markerIDs)
+	}
+
+	if len(result.Markers) != 1 || result.Markers[0].Active {
+		t.Fatalf("unexpected markers: %#v", result.Markers)
+	}
+	if result.Markers[0].WithdrawnAt == nil {
+		t.Fatal("expected withdrawnAt to be mapped")
+	}
+}
+
+func TestCreateSecurityIncidentUpdate_MapsInputsAndResult(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"createSecurityIncidentUpdate": {
+					"securityIncidentUpdate": {
+						"title": "Containment complete",
+						"updateType": "status_changed",
+						"body": "",
+						"occurredAt": "2026-05-03T10:00:00Z"
+					},
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	body := ""
+	customerVisible := false
+	result, err := client.CreateSecurityIncidentUpdate(context.Background(), CreateSecurityIncidentUpdateInput{
+		SecurityIncidentID: "incident-1",
+		Title:              "Containment complete",
+		UpdateType:         "status_changed",
+		OccurredAt:         "2026-05-03T10:00:00Z",
+		Body:               &body,
+		CustomerVisible:    &customerVisible,
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityIncidentUpdate returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["securityIncidentId"] != "incident-1" || request["updateType"] != "status_changed" {
+		t.Fatalf("unexpected update variables: %#v", request)
+	}
+	if request["body"] != "" || request["customerVisible"] != false {
+		t.Fatalf("empty body or false customerVisible not preserved: %#v", request)
+	}
+
+	if result.Update == nil {
+		t.Fatal("expected timeline update")
+	}
+	if result.Update.UpdateType != "status_changed" || result.Update.OccurredAt == nil {
+		t.Fatalf("unexpected update: %#v", result.Update)
+	}
+}
+
+func TestGetSecurityIncidentFindings_MapsNestedComponentContext(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"securityIncident": {
+					"id": "incident-1",
+					"title": "Supply-chain attack",
+					"slug": "supply-chain-attack",
+					"status": "active",
+					"severity": "high",
+					"findings": [
+						{
+							"id": "finding-1",
+							"status": "active",
+							"matchMethod": "purl",
+							"matchedFields": {"purl": true},
+							"firstDetectedAt": "2026-05-01T00:00:00Z",
+							"lastConfirmedAt": "2026-05-02T00:00:00Z",
+							"isPartSbom": true,
+							"component": {
+								"id": "component-1",
+								"name": "example",
+								"version": "1.0.0",
+								"kind": "library",
+								"purl": "pkg:npm/example@1.0.0",
+								"cpes": [],
+								"licensesExp": "MIT",
+								"group": "npm",
+								"primary": false,
+								"internal": false,
+								"sbomId": "sbom-part-1",
+								"updatedAt": "2026-05-02T00:00:00Z",
+								"sbom": {
+									"id": "sbom-part-1",
+									"projectVersion": "1.0.0",
+									"project": {
+										"id": "project-part-1",
+										"name": "library",
+										"projectGroupId": "product-1"
+									}
+								}
+							},
+							"rootSbom": {
+								"id": "sbom-root-1",
+								"projectVersion": "2.0.0",
+								"project": {
+									"id": "project-root-1",
+									"name": "service",
+									"projectGroupId": "product-1"
+								}
+							}
+						}
+					]
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.GetSecurityIncidentFindings(context.Background(), SecurityIncidentFindingsInput{
+		IncidentID: "incident-1",
+		Statuses:   []string{"active"},
+	})
+	if err != nil {
+		t.Fatalf("GetSecurityIncidentFindings returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["id"] != "incident-1" {
+		t.Fatalf("id = %#v, want incident-1", request["id"])
+	}
+	statuses := request["statuses"].([]string)
+	if len(statuses) != 1 || statuses[0] != "active" {
+		t.Fatalf("statuses = %#v, want active", statuses)
+	}
+
+	if result.IncidentID != "incident-1" || len(result.Findings) != 1 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	finding := result.Findings[0]
+	if finding.Component == nil || finding.Component.Name != "example" {
+		t.Fatalf("unexpected component: %#v", finding.Component)
+	}
+	if finding.RootSbom == nil || finding.RootSbom.Project == nil || finding.RootSbom.Project.Name != "service" {
+		t.Fatalf("unexpected root SBOM: %#v", finding.RootSbom)
+	}
+}
+
+func TestSuppressSecurityIncidentFinding_MapsInputsAndFinding(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"suppressSecurityIncidentFinding": {
+					"finding": {
+						"id": "finding-1",
+						"status": "suppressed",
+						"matchMethod": "purl",
+						"matchedFields": {},
+						"firstDetectedAt": "2026-05-01T00:00:00Z",
+						"isPartSbom": false,
+						"component": null,
+						"rootSbom": null
+					},
+					"errors": []
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.SuppressSecurityIncidentFinding(context.Background(), SuppressSecurityIncidentFindingInput{
+		FindingID: "finding-1",
+		Reason:    "False positive",
+	})
+	if err != nil {
+		t.Fatalf("SuppressSecurityIncidentFinding returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["findingId"] != "finding-1" || request["reason"] != "False positive" {
+		t.Fatalf("unexpected suppression variables: %#v", request)
+	}
+	if result.Finding == nil || result.Finding.Status != "suppressed" {
+		t.Fatalf("unexpected finding: %#v", result.Finding)
+	}
+}
+
+func TestSecurityIncidentEnabledOrganizations_MapsResult(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"securityIncidentEnabledOrganizations": [
+					{
+						"id": "org-1",
+						"name": "Interlynk Inc",
+						"securityIncidentsEnabled": true
+					}
+				]
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	orgs, err := client.SecurityIncidentEnabledOrganizations(context.Background())
+	if err != nil {
+		t.Fatalf("SecurityIncidentEnabledOrganizations returned error: %v", err)
+	}
+
+	if len(gql.requests) != 1 || gql.requests[0] != nil {
+		t.Fatalf("unexpected GraphQL variables: %#v", gql.requests)
+	}
+	if len(orgs) != 1 || orgs[0].ID != "org-1" || !orgs[0].SecurityIncidentsEnabled {
+		t.Fatalf("unexpected orgs: %#v", orgs)
+	}
+}

--- a/internal/api/security_incidents_test.go
+++ b/internal/api/security_incidents_test.go
@@ -300,32 +300,3 @@ func TestSuppressSecurityIncidentFinding_MapsInputsAndFinding(t *testing.T) {
 		t.Fatalf("unexpected finding: %#v", result.Finding)
 	}
 }
-
-func TestSecurityIncidentEnabledOrganizations_MapsResult(t *testing.T) {
-	gql := &fakeGraphQLExecutor{
-		pages: []string{
-			`{
-				"securityIncidentEnabledOrganizations": [
-					{
-						"id": "org-1",
-						"name": "Interlynk Inc",
-						"securityIncidentsEnabled": true
-					}
-				]
-			}`,
-		},
-	}
-	client := &Client{gql: gql}
-
-	orgs, err := client.SecurityIncidentEnabledOrganizations(context.Background())
-	if err != nil {
-		t.Fatalf("SecurityIncidentEnabledOrganizations returned error: %v", err)
-	}
-
-	if len(gql.requests) != 1 || gql.requests[0] != nil {
-		t.Fatalf("unexpected GraphQL variables: %#v", gql.requests)
-	}
-	if len(orgs) != 1 || orgs[0].ID != "org-1" || !orgs[0].SecurityIncidentsEnabled {
-		t.Fatalf("unexpected orgs: %#v", orgs)
-	}
-}

--- a/internal/graphql/queries_test.go
+++ b/internal/graphql/queries_test.go
@@ -16,11 +16,26 @@ package graphql
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
 func TestProjectGroupQuery_ProjectsUsesConnectionNodes(t *testing.T) {
 	if !regexp.MustCompile(`projects\s*\([^)]*\)\s*\{\s*nodes\s*\{`).MatchString(ProjectGroupQuery) {
 		t.Fatal("ProjectGroupQuery must select projects through the ProjectConnection nodes field")
+	}
+}
+
+func TestSecurityIncidentCreateUpdateMutation_UsesISO8601DateTime(t *testing.T) {
+	if !strings.Contains(SecurityIncidentCreateUpdateMutation, "$occurredAt: ISO8601DateTime!") {
+		t.Fatal("SecurityIncidentCreateUpdateMutation must use the ISO8601DateTime scalar for occurredAt")
+	}
+}
+
+func TestSecurityIncidentFindingsQuery_SelectsNestedComponentContext(t *testing.T) {
+	for _, required := range []string{"findings(statuses: $statuses)", "component {", "rootSbom {", "projectVersion"} {
+		if !strings.Contains(SecurityIncidentFindingsQuery, required) {
+			t.Fatalf("SecurityIncidentFindingsQuery missing %q", required)
+		}
 	}
 }

--- a/internal/graphql/security_incidents.go
+++ b/internal/graphql/security_incidents.go
@@ -1,0 +1,217 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphql
+
+const securityIncidentFields = `
+	id
+	title
+	slug
+	summary
+	severity
+	status
+	confidence
+	recommendedActions
+	sourceUrls
+	firstSeenAt
+	publishedAt
+	lastUpdatedAt
+	createdAt
+	updatedAt
+	markers {
+		id
+		markerType
+		purl
+		componentName
+		componentVersion
+		githubUrl
+		active
+		addedAt
+		withdrawnAt
+	}
+	orgImpactState {
+		status
+		severity
+		impactedProjectsCount
+		impactedVersionsCount
+		impactedComponentsCount
+		lastEvaluatedAt
+		lastNotifiedAt
+	}
+`
+
+const (
+	// SecurityIncidentsQuery lists security incidents visible to the current organization.
+	SecurityIncidentsQuery = `
+		query SecurityIncidents($status: [String!]) {
+			securityIncidents(status: $status) {
+				` + securityIncidentFields + `
+			}
+		}
+	`
+
+	// SecurityIncidentQuery fetches a single security incident by ID.
+	SecurityIncidentQuery = `
+		query SecurityIncident($id: Uuid!) {
+			securityIncident(id: $id) {
+				` + securityIncidentFields + `
+			}
+		}
+	`
+
+	// SecurityIncidentCreateMutation creates a draft security incident.
+	SecurityIncidentCreateMutation = `
+		mutation CreateSecurityIncident($title: String!, $severity: String!, $confidence: String, $summary: String, $recommendedActions: String, $sourceUrls: String) {
+			createSecurityIncident(input: {
+				title: $title,
+				severity: $severity,
+				confidence: $confidence,
+				summary: $summary,
+				recommendedActions: $recommendedActions,
+				sourceUrls: $sourceUrls
+			}) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentAddMarkersMutation adds markers to an incident.
+	SecurityIncidentAddMarkersMutation = `
+		mutation AddSecurityIncidentMarkers($securityIncidentId: Uuid!, $markers: [SecurityIncidentMarkerInput!]!) {
+			addSecurityIncidentMarkers(input: { securityIncidentId: $securityIncidentId, markers: $markers }) {
+				markers {
+					id
+					markerType
+					purl
+					componentName
+					componentVersion
+					githubUrl
+					active
+					addedAt
+					withdrawnAt
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentPublishMutation publishes a draft incident and queues impact scanning.
+	SecurityIncidentPublishMutation = `
+		mutation PublishSecurityIncident($id: Uuid!) {
+			publishSecurityIncident(input: { id: $id }) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentRerunImpactScanMutation queues impact scanning for an active or resolved incident.
+	SecurityIncidentRerunImpactScanMutation = `
+		mutation RerunSecurityIncidentImpactScan($id: Uuid!) {
+			rerunSecurityIncidentImpactScan(input: { id: $id }) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentDryRunImpactScanMutation queues a dry-run impact scan.
+	SecurityIncidentDryRunImpactScanMutation = `
+		mutation DryRunSecurityIncidentImpactScan($id: Uuid!) {
+			dryRunSecurityIncidentImpactScan(input: { id: $id }) {
+				status
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentDryRunResultQuery fetches dry-run scan status and org summaries.
+	SecurityIncidentDryRunResultQuery = `
+		query SecurityIncidentDryRunResult($incidentId: Uuid!) {
+			securityIncidentDryRunResult(incidentId: $incidentId) {
+				status
+				error
+				completedAt
+				totalOrgsImpacted
+				orgResults {
+					organizationId
+					organizationName
+					impactedComponentsCount
+					impactedProjectsCount
+					impactedVersionsCount
+				}
+			}
+		}
+	`
+
+	// SecurityIncidentDryRunOrgResultQuery fetches dry-run findings for a selected org.
+	SecurityIncidentDryRunOrgResultQuery = `
+		query SecurityIncidentDryRunOrgResult($incidentId: Uuid!, $orgId: Uuid!, $first: Int, $after: String) {
+			securityIncidentDryRunResult(incidentId: $incidentId) {
+				status
+				error
+				completedAt
+				totalOrgsImpacted
+				orgResults {
+					organizationId
+					organizationName
+					impactedComponentsCount
+					impactedProjectsCount
+					impactedVersionsCount
+				}
+				org(orgId: $orgId) {
+					organizationId
+					organizationName
+					impactedComponentsCount
+					impactedProjectsCount
+					impactedVersionsCount
+					findings(first: $first, after: $after) {
+						nodes {
+							id
+							organizationId
+							projectId
+							rootSbomId
+							componentSbomId
+							componentId
+							componentName
+							componentVersion
+							componentPurl
+							markerId
+							markerType
+							markerPurl
+							markerComponentName
+							markerComponentVersion
+							matchMethod
+							matchedFields
+							rootProjectName
+							rootProjectVersion
+							isPartSbom
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`
+)

--- a/internal/graphql/security_incidents.go
+++ b/internal/graphql/security_incidents.go
@@ -51,6 +51,55 @@ const securityIncidentFields = `
 	}
 `
 
+const securityIncidentUpdateFields = `
+	title
+	updateType
+	body
+	occurredAt
+`
+
+const securityIncidentFindingFields = `
+	id
+	status
+	matchMethod
+	matchedFields
+	firstDetectedAt
+	lastConfirmedAt
+	isPartSbom
+	component {
+		id
+		name
+		version
+		kind
+		purl
+		cpes
+		licensesExp
+		group
+		primary
+		internal
+		sbomId
+		updatedAt
+		sbom {
+			id
+			projectVersion
+			project {
+				id
+				name
+				projectGroupId
+			}
+		}
+	}
+	rootSbom {
+		id
+		projectVersion
+		project {
+			id
+			name
+			projectGroupId
+		}
+	}
+`
+
 const (
 	// SecurityIncidentsQuery lists security incidents visible to the current organization.
 	SecurityIncidentsQuery = `
@@ -70,10 +119,46 @@ const (
 		}
 	`
 
+	// SecurityIncidentFindingsQuery fetches customer-visible findings for the current organization.
+	SecurityIncidentFindingsQuery = `
+		query SecurityIncidentFindings($id: Uuid!, $statuses: [SecurityIncidentFindingStatusEnum!]) {
+			securityIncident(id: $id) {
+				id
+				title
+				slug
+				status
+				severity
+				findings(statuses: $statuses) {
+					` + securityIncidentFindingFields + `
+				}
+			}
+		}
+	`
+
 	// SecurityIncidentCreateMutation creates a draft security incident.
 	SecurityIncidentCreateMutation = `
 		mutation CreateSecurityIncident($title: String!, $severity: String!, $confidence: String, $summary: String, $recommendedActions: String, $sourceUrls: String) {
 			createSecurityIncident(input: {
+				title: $title,
+				severity: $severity,
+				confidence: $confidence,
+				summary: $summary,
+				recommendedActions: $recommendedActions,
+				sourceUrls: $sourceUrls
+			}) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentUpdateMutation updates editable incident fields.
+	SecurityIncidentUpdateMutation = `
+		mutation UpdateSecurityIncident($id: Uuid!, $title: String, $severity: String, $confidence: String, $summary: String, $recommendedActions: String, $sourceUrls: String) {
+			updateSecurityIncident(input: {
+				id: $id,
 				title: $title,
 				severity: $severity,
 				confidence: $confidence,
@@ -109,12 +194,87 @@ const (
 		}
 	`
 
+	// SecurityIncidentWithdrawMarkersMutation withdraws active markers from an incident.
+	SecurityIncidentWithdrawMarkersMutation = `
+		mutation WithdrawSecurityIncidentMarkers($securityIncidentId: Uuid!, $markerIds: [Uuid!]!) {
+			withdrawSecurityIncidentMarkers(input: { securityIncidentId: $securityIncidentId, markerIds: $markerIds }) {
+				markers {
+					id
+					markerType
+					purl
+					componentName
+					componentVersion
+					githubUrl
+					active
+					addedAt
+					withdrawnAt
+				}
+				errors
+			}
+		}
+	`
+
 	// SecurityIncidentPublishMutation publishes a draft incident and queues impact scanning.
 	SecurityIncidentPublishMutation = `
 		mutation PublishSecurityIncident($id: Uuid!) {
 			publishSecurityIncident(input: { id: $id }) {
 				securityIncident {
 					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentResolveMutation resolves an active incident.
+	SecurityIncidentResolveMutation = `
+		mutation ResolveSecurityIncident($id: Uuid!) {
+			resolveSecurityIncident(input: { id: $id }) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentArchiveMutation archives an incident.
+	SecurityIncidentArchiveMutation = `
+		mutation ArchiveSecurityIncident($id: Uuid!) {
+			archiveSecurityIncident(input: { id: $id }) {
+				securityIncident {
+					` + securityIncidentFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentCreateUpdateMutation adds a timeline update to an incident.
+	SecurityIncidentCreateUpdateMutation = `
+		mutation CreateSecurityIncidentUpdate($securityIncidentId: Uuid!, $title: String!, $updateType: String!, $occurredAt: ISO8601DateTime!, $body: String, $customerVisible: Boolean = false) {
+			createSecurityIncidentUpdate(input: {
+				securityIncidentId: $securityIncidentId,
+				title: $title,
+				updateType: $updateType,
+				occurredAt: $occurredAt,
+				body: $body,
+				customerVisible: $customerVisible
+			}) {
+				securityIncidentUpdate {
+					` + securityIncidentUpdateFields + `
+				}
+				errors
+			}
+		}
+	`
+
+	// SecurityIncidentSuppressFindingMutation suppresses a finding for the current organization.
+	SecurityIncidentSuppressFindingMutation = `
+		mutation SuppressSecurityIncidentFinding($findingId: Uuid!, $reason: String) {
+			suppressSecurityIncidentFinding(input: { findingId: $findingId, reason: $reason }) {
+				finding {
+					` + securityIncidentFindingFields + `
 				}
 				errors
 			}
@@ -211,6 +371,17 @@ const (
 						}
 					}
 				}
+			}
+		}
+	`
+
+	// SecurityIncidentEnabledOrganizationsQuery lists organizations with incident scans enabled.
+	SecurityIncidentEnabledOrganizationsQuery = `
+		query SecurityIncidentEnabledOrganizations {
+			securityIncidentEnabledOrganizations {
+				id
+				name
+				securityIncidentsEnabled
 			}
 		}
 	`

--- a/internal/graphql/security_incidents.go
+++ b/internal/graphql/security_incidents.go
@@ -374,15 +374,4 @@ const (
 			}
 		}
 	`
-
-	// SecurityIncidentEnabledOrganizationsQuery lists organizations with incident scans enabled.
-	SecurityIncidentEnabledOrganizationsQuery = `
-		query SecurityIncidentEnabledOrganizations {
-			securityIncidentEnabledOrganizations {
-				id
-				name
-				securityIncidentsEnabled
-			}
-		}
-	`
 )

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -248,6 +248,71 @@ func (s *Server) registerTools() {
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
 	), s.handleSearchVulnerabilities)
 
+	// Security incident tools
+	s.mcp.AddTool(mcp.NewTool("list_security_incidents",
+		mcp.WithDescription("List supply-chain security incidents visible to the current organization"),
+		mcp.WithArray("status", mcp.Description("Filter by incident status: draft, active, resolved, archived"), mcp.WithStringItems()),
+	), s.handleListSecurityIncidents)
+
+	s.mcp.AddTool(mcp.NewTool("get_security_incident",
+		mcp.WithDescription("Get a supply-chain security incident by ID, including markers and current organization impact state"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handleGetSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("create_security_incident",
+		mcp.WithDescription("Create a draft supply-chain security incident. Requires operator organization permissions and confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to create the incident")),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Incident title")),
+		mcp.WithString("severity", mcp.Required(), mcp.Description("Incident severity: critical, high, medium, low, unknown")),
+		mcp.WithString("confidence", mcp.Description("Incident confidence: confirmed, likely, investigating")),
+		mcp.WithString("summary", mcp.Description("Incident summary")),
+		mcp.WithString("recommended_actions", mcp.Description("Markdown recommended actions")),
+		mcp.WithString("source_urls", mcp.Description("Markdown source URLs")),
+	), s.handleCreateSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("add_security_incident_markers",
+		mcp.WithDescription("Add markers to a security incident. For active/resolved incidents, marker additions queue impact scanning. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to add markers")),
+		mcp.WithString("security_incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithArray("markers", mcp.Required(), mcp.Description("Marker objects with marker_type and purl/component_name/component_version/github_url"), mcp.Items(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"marker_type":       map[string]interface{}{"type": "string"},
+				"purl":              map[string]interface{}{"type": "string"},
+				"component_name":    map[string]interface{}{"type": "string"},
+				"component_version": map[string]interface{}{"type": "string"},
+				"github_url":        map[string]interface{}{"type": "string"},
+			},
+			"required": []string{"marker_type"},
+		})),
+	), s.handleAddSecurityIncidentMarkers)
+
+	s.mcp.AddTool(mcp.NewTool("publish_security_incident",
+		mcp.WithDescription("Publish a draft security incident and queue the initial impact scan. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to publish the incident")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handlePublishSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("rerun_security_incident_impact_scan",
+		mcp.WithDescription("Queue impact scanning for an active or resolved security incident. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to queue the scan")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handleRerunSecurityIncidentImpactScan)
+
+	s.mcp.AddTool(mcp.NewTool("dry_run_security_incident_impact_scan",
+		mcp.WithDescription("Queue a dry-run impact scan for a security incident with active matchable markers. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to queue the dry-run scan")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handleDryRunSecurityIncidentImpactScan)
+
+	s.mcp.AddTool(mcp.NewTool("get_security_incident_dry_run_result",
+		mcp.WithDescription("Get the latest dry-run impact scan result. Operator-only. Without org_id returns org summaries; with org_id returns paginated findings."),
+		mcp.WithString("incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithString("org_id", mcp.Description("Organization UUID to fetch detailed dry-run findings for")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of findings to return when org_id is provided (default: 50, max: 100)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next findings page")),
+	), s.handleGetSecurityIncidentDryRunResult)
+
 	// Policy tools
 	s.mcp.AddTool(mcp.NewTool("list_policies",
 		mcp.WithDescription("List security policies in the organization"),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -299,13 +299,6 @@ func (s *Server) registerTools() {
 		})),
 	), s.handleAddSecurityIncidentMarkers)
 
-	s.mcp.AddTool(mcp.NewTool("import_security_incident_markers_csv",
-		mcp.WithDescription("Import security incident markers from CSV text. Required column: marker_type. Optional columns: purl, component_name, component_version, github_url. Requires confirm=true."),
-		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to import markers")),
-		mcp.WithString("security_incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
-		mcp.WithString("csv_content", mcp.Required(), mcp.Description("CSV text with marker_type,purl,component_name,component_version,github_url columns")),
-	), s.handleImportSecurityIncidentMarkersCSV)
-
 	s.mcp.AddTool(mcp.NewTool("withdraw_security_incident_markers",
 		mcp.WithDescription("Withdraw active markers from a security incident and resolve related active findings. Requires confirm=true."),
 		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to withdraw markers")),
@@ -368,16 +361,12 @@ func (s *Server) registerTools() {
 	), s.handleDryRunSecurityIncidentImpactScan)
 
 	s.mcp.AddTool(mcp.NewTool("get_security_incident_dry_run_result",
-		mcp.WithDescription("Get the latest dry-run impact scan result. Operator-only. Without org_id returns org summaries; with org_id returns paginated findings."),
+		mcp.WithDescription("Get the latest dry-run impact scan result. Operator-only. Poll no more than once every 2 seconds after queueing a dry run. Without org_id returns org summaries; with org_id returns paginated findings."),
 		mcp.WithString("incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
 		mcp.WithString("org_id", mcp.Description("Organization UUID to fetch detailed dry-run findings for")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of findings to return when org_id is provided (default: 50, max: 100)")),
 		mcp.WithString("after", mcp.Description("Cursor for the next findings page")),
 	), s.handleGetSecurityIncidentDryRunResult)
-
-	s.mcp.AddTool(mcp.NewTool("security_incident_enabled_organizations",
-		mcp.WithDescription("List organizations with security incident scanning enabled. Operator-only."),
-	), s.handleSecurityIncidentEnabledOrganizations)
 
 	// Policy tools
 	s.mcp.AddTool(mcp.NewTool("list_policies",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -270,6 +270,18 @@ func (s *Server) registerTools() {
 		mcp.WithString("source_urls", mcp.Description("Markdown source URLs")),
 	), s.handleCreateSecurityIncident)
 
+	s.mcp.AddTool(mcp.NewTool("update_security_incident",
+		mcp.WithDescription("Update editable fields on a supply-chain security incident. Requires operator organization permissions and confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to update the incident")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithString("title", mcp.Description("Incident title")),
+		mcp.WithString("severity", mcp.Description("Incident severity: critical, high, medium, low, unknown")),
+		mcp.WithString("confidence", mcp.Description("Incident confidence: confirmed, likely, investigating")),
+		mcp.WithString("summary", mcp.Description("Incident summary")),
+		mcp.WithString("recommended_actions", mcp.Description("Markdown recommended actions")),
+		mcp.WithString("source_urls", mcp.Description("Markdown source URLs")),
+	), s.handleUpdateSecurityIncident)
+
 	s.mcp.AddTool(mcp.NewTool("add_security_incident_markers",
 		mcp.WithDescription("Add markers to a security incident. For active/resolved incidents, marker additions queue impact scanning. Requires confirm=true."),
 		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to add markers")),
@@ -287,11 +299,61 @@ func (s *Server) registerTools() {
 		})),
 	), s.handleAddSecurityIncidentMarkers)
 
+	s.mcp.AddTool(mcp.NewTool("import_security_incident_markers_csv",
+		mcp.WithDescription("Import security incident markers from CSV text. Required column: marker_type. Optional columns: purl, component_name, component_version, github_url. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to import markers")),
+		mcp.WithString("security_incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithString("csv_content", mcp.Required(), mcp.Description("CSV text with marker_type,purl,component_name,component_version,github_url columns")),
+	), s.handleImportSecurityIncidentMarkersCSV)
+
+	s.mcp.AddTool(mcp.NewTool("withdraw_security_incident_markers",
+		mcp.WithDescription("Withdraw active markers from a security incident and resolve related active findings. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to withdraw markers")),
+		mcp.WithString("security_incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithArray("marker_ids", mcp.Required(), mcp.Description("Marker UUIDs to withdraw"), mcp.WithStringItems()),
+	), s.handleWithdrawSecurityIncidentMarkers)
+
 	s.mcp.AddTool(mcp.NewTool("publish_security_incident",
 		mcp.WithDescription("Publish a draft security incident and queue the initial impact scan. Requires confirm=true."),
 		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to publish the incident")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
 	), s.handlePublishSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("resolve_security_incident",
+		mcp.WithDescription("Resolve an active security incident. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to resolve the incident")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handleResolveSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("archive_security_incident",
+		mcp.WithDescription("Archive a security incident. Requires confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to archive the incident")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+	), s.handleArchiveSecurityIncident)
+
+	s.mcp.AddTool(mcp.NewTool("create_security_incident_update",
+		mcp.WithDescription("Add a timeline update to a security incident. Requires operator organization permissions and confirm=true."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to create the timeline update")),
+		mcp.WithString("security_incident_id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Update title")),
+		mcp.WithString("update_type", mcp.Required(), mcp.Description("Update type: indicator_added, indicator_withdrawn, guidance_changed, status_changed, source_added, correction")),
+		mcp.WithString("occurred_at", mcp.Required(), mcp.Description("When the update occurred, as ISO8601 datetime")),
+		mcp.WithString("body", mcp.Description("Update body")),
+		mcp.WithBoolean("customer_visible", mcp.Description("Whether this update is visible to customers")),
+	), s.handleCreateSecurityIncidentUpdate)
+
+	s.mcp.AddTool(mcp.NewTool("get_security_incident_findings",
+		mcp.WithDescription("Get customer-facing findings for a security incident in the current organization"),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the security incident")),
+		mcp.WithArray("statuses", mcp.Description("Filter finding statuses: active, resolved, suppressed"), mcp.WithStringItems()),
+	), s.handleGetSecurityIncidentFindings)
+
+	s.mcp.AddTool(mcp.NewTool("suppress_security_incident_finding",
+		mcp.WithDescription("Suppress a specific security incident finding for the current organization. Requires confirm=true and a reason."),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to suppress the finding")),
+		mcp.WithString("finding_id", mcp.Required(), mcp.Description("The UUID of the finding")),
+		mcp.WithString("reason", mcp.Required(), mcp.Description("Suppression reason")),
+	), s.handleSuppressSecurityIncidentFinding)
 
 	s.mcp.AddTool(mcp.NewTool("rerun_security_incident_impact_scan",
 		mcp.WithDescription("Queue impact scanning for an active or resolved security incident. Requires confirm=true."),
@@ -312,6 +374,10 @@ func (s *Server) registerTools() {
 		mcp.WithNumber("limit", mcp.Description("Maximum number of findings to return when org_id is provided (default: 50, max: 100)")),
 		mcp.WithString("after", mcp.Description("Cursor for the next findings page")),
 	), s.handleGetSecurityIncidentDryRunResult)
+
+	s.mcp.AddTool(mcp.NewTool("security_incident_enabled_organizations",
+		mcp.WithDescription("List organizations with security incident scanning enabled. Operator-only."),
+	), s.handleSecurityIncidentEnabledOrganizations)
 
 	// Policy tools
 	s.mcp.AddTool(mcp.NewTool("list_policies",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -868,6 +868,231 @@ func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.Ca
 	})
 }
 
+func (s *Server) handleListSecurityIncidents(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	incidents, err := s.client.ListSecurityIncidents(ctx, api.ListSecurityIncidentsInput{
+		Status: getStringSliceParam(args, "status"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list security incidents: %v", err)), nil
+	}
+
+	formatted := make([]map[string]interface{}, len(incidents))
+	for i := range incidents {
+		formatted[i] = formatSecurityIncident(&incidents[i])
+	}
+
+	return formatResult(map[string]interface{}{
+		"securityIncidents": formatted,
+		"totalCount":        len(formatted),
+	})
+}
+
+func (s *Server) handleGetSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+
+	incident, err := s.client.GetSecurityIncident(ctx, id)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get security incident: %v", err)), nil
+	}
+	if incident == nil {
+		return newToolResultError("Security incident not found"), nil
+	}
+
+	return formatResult(formatSecurityIncident(incident))
+}
+
+func (s *Server) handleCreateSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for create_security_incident"), nil
+	}
+
+	title, ok := args["title"].(string)
+	if !ok || title == "" {
+		return newToolResultError("Missing required parameter: title"), nil
+	}
+	severity, ok := args["severity"].(string)
+	if !ok || severity == "" {
+		return newToolResultError("Missing required parameter: severity"), nil
+	}
+
+	result, err := s.client.CreateSecurityIncident(ctx, api.CreateSecurityIncidentInput{
+		Title:              title,
+		Severity:           severity,
+		Confidence:         getStringPtrParam(args, "confidence"),
+		Summary:            getStringPtrParam(args, "summary"),
+		RecommendedActions: getStringPtrParam(args, "recommended_actions"),
+		SourceURLs:         getStringPtrParam(args, "source_urls"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to create security incident: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to create security incident: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.SecurityIncident == nil {
+		return newToolResultError("Failed to create security incident: API returned no incident"), nil
+	}
+
+	return formatResult(formatSecurityIncident(result.SecurityIncident))
+}
+
+func (s *Server) handleAddSecurityIncidentMarkers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for add_security_incident_markers"), nil
+	}
+
+	incidentID, ok := args["security_incident_id"].(string)
+	if !ok || incidentID == "" {
+		return newToolResultError("Missing required parameter: security_incident_id"), nil
+	}
+	markers, err := getSecurityIncidentMarkerInputsParam(args, "markers")
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	if len(markers) == 0 {
+		return newToolResultError("Missing required parameter: markers"), nil
+	}
+
+	result, err := s.client.AddSecurityIncidentMarkers(ctx, incidentID, markers)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to add security incident markers: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to add security incident markers: %s", strings.Join(result.Errors, "; "))), nil
+	}
+
+	formatted := make([]map[string]interface{}, len(result.Markers))
+	for i := range result.Markers {
+		formatted[i] = formatSecurityIncidentMarker(&result.Markers[i])
+	}
+
+	return formatResult(map[string]interface{}{
+		"markers":      formatted,
+		"totalCount":   len(formatted),
+		"scanBehavior": "If the incident is active or resolved, the API queues impact scanning for the added markers.",
+	})
+}
+
+func (s *Server) handlePublishSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.handleSecurityIncidentMutation(
+		ctx,
+		request,
+		"publish_security_incident",
+		"publish security incident",
+		s.client.PublishSecurityIncident,
+		"Publishing queues the initial impact scan through the incident_published event.",
+	)
+}
+
+func (s *Server) handleRerunSecurityIncidentImpactScan(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.handleSecurityIncidentMutation(
+		ctx,
+		request,
+		"rerun_security_incident_impact_scan",
+		"rerun security incident impact scan",
+		s.client.RerunSecurityIncidentImpactScan,
+		"Impact scanning was queued for this active or resolved incident.",
+	)
+}
+
+func (s *Server) handleDryRunSecurityIncidentImpactScan(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for dry_run_security_incident_impact_scan"), nil
+	}
+
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+
+	result, err := s.client.DryRunSecurityIncidentImpactScan(ctx, id)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to queue dry-run impact scan: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to queue dry-run impact scan: %s", strings.Join(result.Errors, "; "))), nil
+	}
+
+	return formatResult(map[string]interface{}{
+		"status":       result.Status,
+		"scanBehavior": "Dry-run impact scanning was queued; poll get_security_incident_dry_run_result for status and findings.",
+	})
+}
+
+func (s *Server) handleGetSecurityIncidentDryRunResult(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	incidentID, ok := args["incident_id"].(string)
+	if !ok || incidentID == "" {
+		incidentID, _ = args["id"].(string)
+	}
+	if incidentID == "" {
+		return newToolResultError("Missing required parameter: incident_id"), nil
+	}
+
+	input := api.SecurityIncidentDryRunResultInput{
+		IncidentID: incidentID,
+		First:      getIntParam(args, "limit", 50),
+	}
+	if input.First > 100 {
+		input.First = 100
+	}
+	if orgID, ok := args["org_id"].(string); ok {
+		input.OrgID = orgID
+	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
+
+	result, err := s.client.GetSecurityIncidentDryRunResult(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get dry-run result: %v", err)), nil
+	}
+
+	return formatResult(formatSecurityIncidentDryRunResult(result))
+}
+
+func (s *Server) handleSecurityIncidentMutation(
+	ctx context.Context,
+	request mcp.CallToolRequest,
+	toolName string,
+	actionName string,
+	mutation func(context.Context, string) (*api.SecurityIncidentMutationResult, error),
+	scanBehavior string,
+) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError(fmt.Sprintf("Missing required confirmation: confirm must be true for %s", toolName)), nil
+	}
+
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+
+	result, err := mutation(ctx, id)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to %s: %v", actionName, err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to %s: %s", actionName, strings.Join(result.Errors, "; "))), nil
+	}
+	if result.SecurityIncident == nil {
+		return newToolResultError(fmt.Sprintf("Failed to %s: API returned no incident", actionName)), nil
+	}
+
+	formatted := formatSecurityIncident(result.SecurityIncident)
+	formatted["scanBehavior"] = scanBehavior
+	return formatResult(formatted)
+}
+
 func (s *Server) handleListPolicies(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	input := api.ListPoliciesInput{
@@ -1300,6 +1525,178 @@ func getComponentVulnCustomFieldInputsParam(args map[string]interface{}, key str
 		result = append(result, input)
 	}
 	return &result, nil
+}
+
+func getSecurityIncidentMarkerInputsParam(args map[string]interface{}, key string) ([]api.SecurityIncidentMarkerInput, error) {
+	val, ok := args[key]
+	if !ok {
+		return nil, nil
+	}
+	items, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	result := make([]api.SecurityIncidentMarkerInput, 0, len(items))
+	for i, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be an object", key, i)
+		}
+
+		markerType, _ := obj["marker_type"].(string)
+		if markerType == "" {
+			markerType, _ = obj["markerType"].(string)
+		}
+		if markerType == "" {
+			return nil, fmt.Errorf("%s[%d] requires marker_type", key, i)
+		}
+
+		input := api.SecurityIncidentMarkerInput{MarkerType: markerType}
+		input.Purl, _ = obj["purl"].(string)
+		input.ComponentName, _ = obj["component_name"].(string)
+		if input.ComponentName == "" {
+			input.ComponentName, _ = obj["componentName"].(string)
+		}
+		input.ComponentVersion, _ = obj["component_version"].(string)
+		if input.ComponentVersion == "" {
+			input.ComponentVersion, _ = obj["componentVersion"].(string)
+		}
+		input.GithubURL, _ = obj["github_url"].(string)
+		if input.GithubURL == "" {
+			input.GithubURL, _ = obj["githubUrl"].(string)
+		}
+		result = append(result, input)
+	}
+	return result, nil
+}
+
+func formatSecurityIncident(incident *api.SecurityIncident) map[string]interface{} {
+	markers := make([]map[string]interface{}, len(incident.Markers))
+	for i := range incident.Markers {
+		markers[i] = formatSecurityIncidentMarker(&incident.Markers[i])
+	}
+
+	result := map[string]interface{}{
+		"id":                 incident.ID,
+		"title":              incident.Title,
+		"slug":               incident.Slug,
+		"summary":            incident.Summary,
+		"severity":           incident.Severity,
+		"status":             incident.Status,
+		"confidence":         incident.Confidence,
+		"recommendedActions": incident.RecommendedActions,
+		"sourceUrls":         incident.SourceURLs,
+		"firstSeenAt":        incident.FirstSeenAt,
+		"publishedAt":        incident.PublishedAt,
+		"lastUpdatedAt":      incident.LastUpdatedAt,
+		"createdAt":          incident.CreatedAt,
+		"updatedAt":          incident.UpdatedAt,
+		"markers":            markers,
+		"activeMarkerCount":  activeSecurityIncidentMarkerCount(incident.Markers),
+	}
+
+	if incident.OrgImpactState != nil {
+		result["orgImpactState"] = map[string]interface{}{
+			"status":                  incident.OrgImpactState.Status,
+			"severity":                incident.OrgImpactState.Severity,
+			"impactedProjectsCount":   incident.OrgImpactState.ImpactedProjectsCount,
+			"impactedVersionsCount":   incident.OrgImpactState.ImpactedVersionsCount,
+			"impactedComponentsCount": incident.OrgImpactState.ImpactedComponentsCount,
+			"lastEvaluatedAt":         incident.OrgImpactState.LastEvaluatedAt,
+			"lastNotifiedAt":          incident.OrgImpactState.LastNotifiedAt,
+		}
+	}
+
+	return result
+}
+
+func formatSecurityIncidentMarker(marker *api.SecurityIncidentMarker) map[string]interface{} {
+	return map[string]interface{}{
+		"id":               marker.ID,
+		"markerType":       marker.MarkerType,
+		"purl":             marker.Purl,
+		"componentName":    marker.ComponentName,
+		"componentVersion": marker.ComponentVersion,
+		"githubUrl":        marker.GithubURL,
+		"active":           marker.Active,
+		"addedAt":          marker.AddedAt,
+		"withdrawnAt":      marker.WithdrawnAt,
+	}
+}
+
+func activeSecurityIncidentMarkerCount(markers []api.SecurityIncidentMarker) int {
+	count := 0
+	for _, marker := range markers {
+		if marker.Active {
+			count++
+		}
+	}
+	return count
+}
+
+func formatSecurityIncidentDryRunResult(result *api.SecurityIncidentDryRunResult) map[string]interface{} {
+	orgResults := make([]map[string]interface{}, len(result.OrgResults))
+	for i := range result.OrgResults {
+		orgResults[i] = formatSecurityIncidentDryRunOrgResult(&result.OrgResults[i])
+	}
+
+	formatted := map[string]interface{}{
+		"status":            result.Status,
+		"error":             result.Error,
+		"completedAt":       result.CompletedAt,
+		"totalOrgsImpacted": result.TotalOrgsImpacted,
+		"orgResults":        orgResults,
+	}
+
+	if result.Org != nil {
+		findings := make([]map[string]interface{}, len(result.Org.Findings))
+		for i := range result.Org.Findings {
+			findings[i] = formatSecurityIncidentDryRunFinding(&result.Org.Findings[i])
+		}
+		org := formatSecurityIncidentDryRunOrgResult(&result.Org.SecurityIncidentDryRunOrgResult)
+		org["findings"] = findings
+		org["pageInfo"] = map[string]interface{}{
+			"hasNextPage": result.Org.HasNextPage,
+			"endCursor":   result.Org.EndCursor,
+		}
+		formatted["org"] = org
+	}
+
+	return formatted
+}
+
+func formatSecurityIncidentDryRunOrgResult(org *api.SecurityIncidentDryRunOrgResult) map[string]interface{} {
+	return map[string]interface{}{
+		"organizationId":          org.OrganizationID,
+		"organizationName":        org.OrganizationName,
+		"impactedComponentsCount": org.ImpactedComponentsCount,
+		"impactedProjectsCount":   org.ImpactedProjectsCount,
+		"impactedVersionsCount":   org.ImpactedVersionsCount,
+	}
+}
+
+func formatSecurityIncidentDryRunFinding(finding *api.SecurityIncidentDryRunFinding) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                     finding.ID,
+		"organizationId":         finding.OrganizationID,
+		"projectId":              finding.ProjectID,
+		"rootSbomId":             finding.RootSbomID,
+		"componentSbomId":        finding.ComponentSbomID,
+		"componentId":            finding.ComponentID,
+		"componentName":          finding.ComponentName,
+		"componentVersion":       finding.ComponentVersion,
+		"componentPurl":          finding.ComponentPurl,
+		"markerId":               finding.MarkerID,
+		"markerType":             finding.MarkerType,
+		"markerPurl":             finding.MarkerPurl,
+		"markerComponentName":    finding.MarkerComponentName,
+		"markerComponentVersion": finding.MarkerComponentVersion,
+		"matchMethod":            finding.MatchMethod,
+		"matchedFields":          finding.MatchedFields,
+		"rootProjectName":        finding.RootProjectName,
+		"rootProjectVersion":     finding.RootProjectVersion,
+		"isPartSbom":             finding.IsPartSbom,
+	}
 }
 
 func formatComponent(component *api.VersionComponent) map[string]interface{} {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,7 +16,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -1017,49 +1016,6 @@ func (s *Server) handleAddSecurityIncidentMarkers(ctx context.Context, request m
 	})
 }
 
-func (s *Server) handleImportSecurityIncidentMarkersCSV(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := toolArguments(request)
-	if !confirmed(args) {
-		return newToolResultError("Missing required confirmation: confirm must be true for import_security_incident_markers_csv"), nil
-	}
-
-	incidentID, ok := args["security_incident_id"].(string)
-	if !ok || incidentID == "" {
-		return newToolResultError("Missing required parameter: security_incident_id"), nil
-	}
-	csvContent, ok := args["csv_content"].(string)
-	if !ok || strings.TrimSpace(csvContent) == "" {
-		return newToolResultError("Missing required parameter: csv_content"), nil
-	}
-
-	markers, err := getSecurityIncidentMarkerInputsCSV(csvContent)
-	if err != nil {
-		return newToolResultError(err.Error()), nil
-	}
-	if len(markers) == 0 {
-		return newToolResultError("CSV did not contain any marker rows"), nil
-	}
-
-	result, err := s.client.AddSecurityIncidentMarkers(ctx, incidentID, markers)
-	if err != nil {
-		return newToolResultError(fmt.Sprintf("Failed to import security incident markers from CSV: %v", err)), nil
-	}
-	if len(result.Errors) > 0 {
-		return newToolResultError(fmt.Sprintf("Failed to import security incident markers from CSV: %s", strings.Join(result.Errors, "; "))), nil
-	}
-
-	formatted := make([]map[string]interface{}, len(result.Markers))
-	for i := range result.Markers {
-		formatted[i] = formatSecurityIncidentMarker(&result.Markers[i])
-	}
-
-	return formatResult(map[string]interface{}{
-		"markers":      formatted,
-		"totalCount":   len(formatted),
-		"scanBehavior": "CSV rows were parsed locally and submitted through addSecurityIncidentMarkers; active/resolved incidents queue impact scanning for added markers.",
-	})
-}
-
 func (s *Server) handleWithdrawSecurityIncidentMarkers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	if !confirmed(args) {
@@ -1257,7 +1213,7 @@ func (s *Server) handleDryRunSecurityIncidentImpactScan(ctx context.Context, req
 
 	return formatResult(map[string]interface{}{
 		"status":       result.Status,
-		"scanBehavior": "Dry-run impact scanning was queued; poll get_security_incident_dry_run_result for status and findings.",
+		"scanBehavior": "Dry-run impact scanning was queued; poll get_security_incident_dry_run_result for status and findings no more than once every 2 seconds.",
 	})
 }
 
@@ -1291,27 +1247,6 @@ func (s *Server) handleGetSecurityIncidentDryRunResult(ctx context.Context, requ
 	}
 
 	return formatResult(formatSecurityIncidentDryRunResult(result))
-}
-
-func (s *Server) handleSecurityIncidentEnabledOrganizations(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	organizations, err := s.client.SecurityIncidentEnabledOrganizations(ctx)
-	if err != nil {
-		return newToolResultError(fmt.Sprintf("Failed to list security incident enabled organizations: %v", err)), nil
-	}
-
-	formatted := make([]map[string]interface{}, len(organizations))
-	for i := range organizations {
-		formatted[i] = map[string]interface{}{
-			"id":                       organizations[i].ID,
-			"name":                     organizations[i].Name,
-			"securityIncidentsEnabled": organizations[i].SecurityIncidentsEnabled,
-		}
-	}
-
-	return formatResult(map[string]interface{}{
-		"organizations": formatted,
-		"totalCount":    len(formatted),
-	})
 }
 
 func (s *Server) handleSecurityIncidentMutation(
@@ -1823,64 +1758,6 @@ func getSecurityIncidentMarkerInputsParam(args map[string]interface{}, key strin
 		result = append(result, input)
 	}
 	return result, nil
-}
-
-func getSecurityIncidentMarkerInputsCSV(csvContent string) ([]api.SecurityIncidentMarkerInput, error) {
-	reader := csv.NewReader(strings.NewReader(csvContent))
-	reader.TrimLeadingSpace = true
-	records, err := reader.ReadAll()
-	if err != nil {
-		return nil, fmt.Errorf("csv_content is invalid: %w", err)
-	}
-	if len(records) == 0 {
-		return nil, fmt.Errorf("csv_content requires a header row")
-	}
-
-	headers := make(map[string]int, len(records[0]))
-	for i, header := range records[0] {
-		headers[strings.TrimSpace(header)] = i
-	}
-	if _, ok := headers["marker_type"]; !ok {
-		return nil, fmt.Errorf("csv_content missing required column: marker_type")
-	}
-
-	result := make([]api.SecurityIncidentMarkerInput, 0, len(records)-1)
-	for i, row := range records[1:] {
-		if csvRowBlank(row) {
-			continue
-		}
-
-		markerType := csvColumnValue(headers, row, "marker_type")
-		if markerType == "" {
-			return nil, fmt.Errorf("csv row %d requires marker_type", i+2)
-		}
-
-		result = append(result, api.SecurityIncidentMarkerInput{
-			MarkerType:       markerType,
-			Purl:             csvColumnValue(headers, row, "purl"),
-			ComponentName:    csvColumnValue(headers, row, "component_name"),
-			ComponentVersion: csvColumnValue(headers, row, "component_version"),
-			GithubURL:        csvColumnValue(headers, row, "github_url"),
-		})
-	}
-	return result, nil
-}
-
-func csvColumnValue(headers map[string]int, row []string, key string) string {
-	index, ok := headers[key]
-	if !ok || index >= len(row) {
-		return ""
-	}
-	return strings.TrimSpace(row[index])
-}
-
-func csvRowBlank(row []string) bool {
-	for _, value := range row {
-		if strings.TrimSpace(value) != "" {
-			return false
-		}
-	}
-	return true
 }
 
 func formatSecurityIncident(incident *api.SecurityIncident) map[string]interface{} {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,6 +16,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -942,6 +943,42 @@ func (s *Server) handleCreateSecurityIncident(ctx context.Context, request mcp.C
 	return formatResult(formatSecurityIncident(result.SecurityIncident))
 }
 
+func (s *Server) handleUpdateSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for update_security_incident"), nil
+	}
+
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+	if !hasAnyParam(args, "title", "severity", "confidence", "summary", "recommended_actions", "source_urls") {
+		return newToolResultError("At least one editable field must be provided"), nil
+	}
+
+	result, err := s.client.UpdateSecurityIncident(ctx, api.UpdateSecurityIncidentInput{
+		ID:                 id,
+		Title:              getStringPtrParam(args, "title"),
+		Severity:           getStringPtrParam(args, "severity"),
+		Confidence:         getStringPtrParam(args, "confidence"),
+		Summary:            getStringPtrParam(args, "summary"),
+		RecommendedActions: getStringPtrParam(args, "recommended_actions"),
+		SourceURLs:         getStringPtrParam(args, "source_urls"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to update security incident: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to update security incident: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.SecurityIncident == nil {
+		return newToolResultError("Failed to update security incident: API returned no incident"), nil
+	}
+
+	return formatResult(formatSecurityIncident(result.SecurityIncident))
+}
+
 func (s *Server) handleAddSecurityIncidentMarkers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	if !confirmed(args) {
@@ -980,6 +1017,84 @@ func (s *Server) handleAddSecurityIncidentMarkers(ctx context.Context, request m
 	})
 }
 
+func (s *Server) handleImportSecurityIncidentMarkersCSV(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for import_security_incident_markers_csv"), nil
+	}
+
+	incidentID, ok := args["security_incident_id"].(string)
+	if !ok || incidentID == "" {
+		return newToolResultError("Missing required parameter: security_incident_id"), nil
+	}
+	csvContent, ok := args["csv_content"].(string)
+	if !ok || strings.TrimSpace(csvContent) == "" {
+		return newToolResultError("Missing required parameter: csv_content"), nil
+	}
+
+	markers, err := getSecurityIncidentMarkerInputsCSV(csvContent)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	if len(markers) == 0 {
+		return newToolResultError("CSV did not contain any marker rows"), nil
+	}
+
+	result, err := s.client.AddSecurityIncidentMarkers(ctx, incidentID, markers)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to import security incident markers from CSV: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to import security incident markers from CSV: %s", strings.Join(result.Errors, "; "))), nil
+	}
+
+	formatted := make([]map[string]interface{}, len(result.Markers))
+	for i := range result.Markers {
+		formatted[i] = formatSecurityIncidentMarker(&result.Markers[i])
+	}
+
+	return formatResult(map[string]interface{}{
+		"markers":      formatted,
+		"totalCount":   len(formatted),
+		"scanBehavior": "CSV rows were parsed locally and submitted through addSecurityIncidentMarkers; active/resolved incidents queue impact scanning for added markers.",
+	})
+}
+
+func (s *Server) handleWithdrawSecurityIncidentMarkers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for withdraw_security_incident_markers"), nil
+	}
+
+	incidentID, ok := args["security_incident_id"].(string)
+	if !ok || incidentID == "" {
+		return newToolResultError("Missing required parameter: security_incident_id"), nil
+	}
+	markerIDs := getStringSliceParam(args, "marker_ids")
+	if len(markerIDs) == 0 {
+		return newToolResultError("Missing required parameter: marker_ids"), nil
+	}
+
+	result, err := s.client.WithdrawSecurityIncidentMarkers(ctx, incidentID, markerIDs)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to withdraw security incident markers: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to withdraw security incident markers: %s", strings.Join(result.Errors, "; "))), nil
+	}
+
+	formatted := make([]map[string]interface{}, len(result.Markers))
+	for i := range result.Markers {
+		formatted[i] = formatSecurityIncidentMarker(&result.Markers[i])
+	}
+
+	return formatResult(map[string]interface{}{
+		"markers":      formatted,
+		"totalCount":   len(formatted),
+		"scanBehavior": "Active findings for withdrawn markers were resolved and organization impact state was recalculated by the API.",
+	})
+}
+
 func (s *Server) handlePublishSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return s.handleSecurityIncidentMutation(
 		ctx,
@@ -989,6 +1104,125 @@ func (s *Server) handlePublishSecurityIncident(ctx context.Context, request mcp.
 		s.client.PublishSecurityIncident,
 		"Publishing queues the initial impact scan through the incident_published event.",
 	)
+}
+
+func (s *Server) handleResolveSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.handleSecurityIncidentMutation(
+		ctx,
+		request,
+		"resolve_security_incident",
+		"resolve security incident",
+		s.client.ResolveSecurityIncident,
+		"Resolving emits an incident_resolved event for downstream state updates.",
+	)
+}
+
+func (s *Server) handleArchiveSecurityIncident(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return s.handleSecurityIncidentMutation(
+		ctx,
+		request,
+		"archive_security_incident",
+		"archive security incident",
+		s.client.ArchiveSecurityIncident,
+		"Archiving emits an incident_archived event.",
+	)
+}
+
+func (s *Server) handleCreateSecurityIncidentUpdate(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for create_security_incident_update"), nil
+	}
+
+	incidentID, ok := args["security_incident_id"].(string)
+	if !ok || incidentID == "" {
+		return newToolResultError("Missing required parameter: security_incident_id"), nil
+	}
+	title, ok := args["title"].(string)
+	if !ok || title == "" {
+		return newToolResultError("Missing required parameter: title"), nil
+	}
+	updateType, ok := args["update_type"].(string)
+	if !ok || updateType == "" {
+		return newToolResultError("Missing required parameter: update_type"), nil
+	}
+	occurredAt, ok := args["occurred_at"].(string)
+	if !ok || occurredAt == "" {
+		return newToolResultError("Missing required parameter: occurred_at"), nil
+	}
+
+	result, err := s.client.CreateSecurityIncidentUpdate(ctx, api.CreateSecurityIncidentUpdateInput{
+		SecurityIncidentID: incidentID,
+		Title:              title,
+		UpdateType:         updateType,
+		OccurredAt:         occurredAt,
+		Body:               getStringPtrParam(args, "body"),
+		CustomerVisible:    getBoolPtrParam(args, "customer_visible"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to create security incident update: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to create security incident update: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.Update == nil {
+		return newToolResultError("Failed to create security incident update: API returned no update"), nil
+	}
+
+	return formatResult(formatSecurityIncidentUpdate(result.Update))
+}
+
+func (s *Server) handleGetSecurityIncidentFindings(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return newToolResultError("Missing required parameter: id"), nil
+	}
+
+	result, err := s.client.GetSecurityIncidentFindings(ctx, api.SecurityIncidentFindingsInput{
+		IncidentID: id,
+		Statuses:   getStringSliceParam(args, "statuses"),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get security incident findings: %v", err)), nil
+	}
+	if result == nil {
+		return newToolResultError("Security incident not found"), nil
+	}
+
+	return formatResult(formatSecurityIncidentFindingsResult(result))
+}
+
+func (s *Server) handleSuppressSecurityIncidentFinding(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for suppress_security_incident_finding"), nil
+	}
+
+	findingID, ok := args["finding_id"].(string)
+	if !ok || findingID == "" {
+		return newToolResultError("Missing required parameter: finding_id"), nil
+	}
+	reason, ok := args["reason"].(string)
+	if !ok || strings.TrimSpace(reason) == "" {
+		return newToolResultError("Missing required parameter: reason"), nil
+	}
+
+	result, err := s.client.SuppressSecurityIncidentFinding(ctx, api.SuppressSecurityIncidentFindingInput{
+		FindingID: findingID,
+		Reason:    reason,
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to suppress security incident finding: %v", err)), nil
+	}
+	if len(result.Errors) > 0 {
+		return newToolResultError(fmt.Sprintf("Failed to suppress security incident finding: %s", strings.Join(result.Errors, "; "))), nil
+	}
+	if result.Finding == nil {
+		return newToolResultError("Failed to suppress security incident finding: API returned no finding"), nil
+	}
+
+	return formatResult(formatSecurityIncidentFinding(result.Finding))
 }
 
 func (s *Server) handleRerunSecurityIncidentImpactScan(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1057,6 +1291,27 @@ func (s *Server) handleGetSecurityIncidentDryRunResult(ctx context.Context, requ
 	}
 
 	return formatResult(formatSecurityIncidentDryRunResult(result))
+}
+
+func (s *Server) handleSecurityIncidentEnabledOrganizations(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	organizations, err := s.client.SecurityIncidentEnabledOrganizations(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list security incident enabled organizations: %v", err)), nil
+	}
+
+	formatted := make([]map[string]interface{}, len(organizations))
+	for i := range organizations {
+		formatted[i] = map[string]interface{}{
+			"id":                       organizations[i].ID,
+			"name":                     organizations[i].Name,
+			"securityIncidentsEnabled": organizations[i].SecurityIncidentsEnabled,
+		}
+	}
+
+	return formatResult(map[string]interface{}{
+		"organizations": formatted,
+		"totalCount":    len(formatted),
+	})
 }
 
 func (s *Server) handleSecurityIncidentMutation(
@@ -1570,6 +1825,64 @@ func getSecurityIncidentMarkerInputsParam(args map[string]interface{}, key strin
 	return result, nil
 }
 
+func getSecurityIncidentMarkerInputsCSV(csvContent string) ([]api.SecurityIncidentMarkerInput, error) {
+	reader := csv.NewReader(strings.NewReader(csvContent))
+	reader.TrimLeadingSpace = true
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("csv_content is invalid: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("csv_content requires a header row")
+	}
+
+	headers := make(map[string]int, len(records[0]))
+	for i, header := range records[0] {
+		headers[strings.TrimSpace(header)] = i
+	}
+	if _, ok := headers["marker_type"]; !ok {
+		return nil, fmt.Errorf("csv_content missing required column: marker_type")
+	}
+
+	result := make([]api.SecurityIncidentMarkerInput, 0, len(records)-1)
+	for i, row := range records[1:] {
+		if csvRowBlank(row) {
+			continue
+		}
+
+		markerType := csvColumnValue(headers, row, "marker_type")
+		if markerType == "" {
+			return nil, fmt.Errorf("csv row %d requires marker_type", i+2)
+		}
+
+		result = append(result, api.SecurityIncidentMarkerInput{
+			MarkerType:       markerType,
+			Purl:             csvColumnValue(headers, row, "purl"),
+			ComponentName:    csvColumnValue(headers, row, "component_name"),
+			ComponentVersion: csvColumnValue(headers, row, "component_version"),
+			GithubURL:        csvColumnValue(headers, row, "github_url"),
+		})
+	}
+	return result, nil
+}
+
+func csvColumnValue(headers map[string]int, row []string, key string) string {
+	index, ok := headers[key]
+	if !ok || index >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[index])
+}
+
+func csvRowBlank(row []string) bool {
+	for _, value := range row {
+		if strings.TrimSpace(value) != "" {
+			return false
+		}
+	}
+	return true
+}
+
 func formatSecurityIncident(incident *api.SecurityIncident) map[string]interface{} {
 	markers := make([]map[string]interface{}, len(incident.Markers))
 	for i := range incident.Markers {
@@ -1610,6 +1923,15 @@ func formatSecurityIncident(incident *api.SecurityIncident) map[string]interface
 	return result
 }
 
+func formatSecurityIncidentUpdate(update *api.SecurityIncidentUpdate) map[string]interface{} {
+	return map[string]interface{}{
+		"title":      update.Title,
+		"updateType": update.UpdateType,
+		"body":       update.Body,
+		"occurredAt": update.OccurredAt,
+	}
+}
+
 func formatSecurityIncidentMarker(marker *api.SecurityIncidentMarker) map[string]interface{} {
 	return map[string]interface{}{
 		"id":               marker.ID,
@@ -1632,6 +1954,95 @@ func activeSecurityIncidentMarkerCount(markers []api.SecurityIncidentMarker) int
 		}
 	}
 	return count
+}
+
+func formatSecurityIncidentFindingsResult(result *api.SecurityIncidentFindingsResult) map[string]interface{} {
+	findings := make([]map[string]interface{}, len(result.Findings))
+	for i := range result.Findings {
+		findings[i] = formatSecurityIncidentFinding(&result.Findings[i])
+	}
+
+	return map[string]interface{}{
+		"incidentId": result.IncidentID,
+		"title":      result.Title,
+		"slug":       result.Slug,
+		"status":     result.Status,
+		"severity":   result.Severity,
+		"findings":   findings,
+		"totalCount": len(findings),
+	}
+}
+
+func formatSecurityIncidentFinding(finding *api.SecurityIncidentFinding) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":              finding.ID,
+		"status":          finding.Status,
+		"matchMethod":     finding.MatchMethod,
+		"matchedFields":   finding.MatchedFields,
+		"firstDetectedAt": finding.FirstDetectedAt,
+		"lastConfirmedAt": finding.LastConfirmedAt,
+		"isPartSbom":      finding.IsPartSbom,
+	}
+
+	if finding.Component != nil {
+		result["component"] = formatSecurityIncidentFindingComponent(finding.Component)
+		result["componentId"] = finding.Component.ID
+		result["componentName"] = finding.Component.Name
+		result["componentVersion"] = finding.Component.Version
+		result["componentPurl"] = finding.Component.Purl
+		result["componentSbomId"] = finding.Component.SbomID
+		if finding.Component.Sbom != nil {
+			result["componentSbomProjectVersion"] = finding.Component.Sbom.ProjectVersion
+		}
+	}
+
+	if finding.RootSbom != nil {
+		result["rootSbom"] = formatSecurityIncidentFindingSbom(finding.RootSbom)
+		result["rootSbomId"] = finding.RootSbom.ID
+		result["rootProjectVersion"] = finding.RootSbom.ProjectVersion
+		if finding.RootSbom.Project != nil {
+			result["rootProjectId"] = finding.RootSbom.Project.ID
+			result["rootProjectName"] = finding.RootSbom.Project.Name
+		}
+	}
+
+	return result
+}
+
+func formatSecurityIncidentFindingComponent(component *api.SecurityIncidentFindingComponent) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":          component.ID,
+		"name":        component.Name,
+		"version":     component.Version,
+		"kind":        component.Kind,
+		"purl":        component.Purl,
+		"cpes":        component.Cpes,
+		"licensesExp": component.LicensesExp,
+		"group":       component.Group,
+		"primary":     component.Primary,
+		"internal":    component.Internal,
+		"sbomId":      component.SbomID,
+		"updatedAt":   component.UpdatedAt,
+	}
+	if component.Sbom != nil {
+		result["sbom"] = formatSecurityIncidentFindingSbom(component.Sbom)
+	}
+	return result
+}
+
+func formatSecurityIncidentFindingSbom(sbom *api.SecurityIncidentFindingSbom) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":             sbom.ID,
+		"projectVersion": sbom.ProjectVersion,
+	}
+	if sbom.Project != nil {
+		result["project"] = map[string]interface{}{
+			"id":             sbom.Project.ID,
+			"name":           sbom.Project.Name,
+			"projectGroupId": sbom.Project.ProjectGroupID,
+		}
+	}
+	return result
 }
 
 func formatSecurityIncidentDryRunResult(result *api.SecurityIncidentDryRunResult) map[string]interface{} {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -32,37 +32,3 @@ func TestSameVexName_NormalizesCommonInputForms(t *testing.T) {
 		}
 	}
 }
-
-func TestGetSecurityIncidentMarkerInputsCSV_ParsesRows(t *testing.T) {
-	markers, err := getSecurityIncidentMarkerInputsCSV(`marker_type,purl,component_name,component_version,github_url
-purl,pkg:npm/example@1.0.0,,,
-name_version,,example,1.0.0,https://github.com/example/repo
-,,,,`)
-	if err != nil {
-		t.Fatalf("getSecurityIncidentMarkerInputsCSV returned error: %v", err)
-	}
-
-	if len(markers) != 2 {
-		t.Fatalf("len(markers) = %d, want 2", len(markers))
-	}
-	if markers[0].MarkerType != "purl" || markers[0].Purl != "pkg:npm/example@1.0.0" {
-		t.Fatalf("unexpected first marker: %#v", markers[0])
-	}
-	if markers[1].MarkerType != "name_version" || markers[1].ComponentName != "example" || markers[1].GithubURL == "" {
-		t.Fatalf("unexpected second marker: %#v", markers[1])
-	}
-}
-
-func TestGetSecurityIncidentMarkerInputsCSV_RequiresMarkerTypeHeader(t *testing.T) {
-	_, err := getSecurityIncidentMarkerInputsCSV("purl\npkg:npm/example@1.0.0\n")
-	if err == nil {
-		t.Fatal("expected missing marker_type header error")
-	}
-}
-
-func TestGetSecurityIncidentMarkerInputsCSV_RequiresMarkerTypeValue(t *testing.T) {
-	_, err := getSecurityIncidentMarkerInputsCSV("marker_type,purl\n,pkg:npm/example@1.0.0\n")
-	if err == nil {
-		t.Fatal("expected missing marker_type value error")
-	}
-}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -32,3 +32,37 @@ func TestSameVexName_NormalizesCommonInputForms(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSecurityIncidentMarkerInputsCSV_ParsesRows(t *testing.T) {
+	markers, err := getSecurityIncidentMarkerInputsCSV(`marker_type,purl,component_name,component_version,github_url
+purl,pkg:npm/example@1.0.0,,,
+name_version,,example,1.0.0,https://github.com/example/repo
+,,,,`)
+	if err != nil {
+		t.Fatalf("getSecurityIncidentMarkerInputsCSV returned error: %v", err)
+	}
+
+	if len(markers) != 2 {
+		t.Fatalf("len(markers) = %d, want 2", len(markers))
+	}
+	if markers[0].MarkerType != "purl" || markers[0].Purl != "pkg:npm/example@1.0.0" {
+		t.Fatalf("unexpected first marker: %#v", markers[0])
+	}
+	if markers[1].MarkerType != "name_version" || markers[1].ComponentName != "example" || markers[1].GithubURL == "" {
+		t.Fatalf("unexpected second marker: %#v", markers[1])
+	}
+}
+
+func TestGetSecurityIncidentMarkerInputsCSV_RequiresMarkerTypeHeader(t *testing.T) {
+	_, err := getSecurityIncidentMarkerInputsCSV("purl\npkg:npm/example@1.0.0\n")
+	if err == nil {
+		t.Fatal("expected missing marker_type header error")
+	}
+}
+
+func TestGetSecurityIncidentMarkerInputsCSV_RequiresMarkerTypeValue(t *testing.T) {
+	_, err := getSecurityIncidentMarkerInputsCSV("marker_type,purl\n,pkg:npm/example@1.0.0\n")
+	if err == nil {
+		t.Fatal("expected missing marker_type value error")
+	}
+}


### PR DESCRIPTION
**Add MCP incident tools**

- `list_security_incidents`
- `get_security_incident`
- `create_security_incident`
- `add_security_incident_markers`
- `publish_security_incident`
- `rerun_security_incident_impact_scan`
- `dry_run_security_incident_impact_scan`
- `get_security_incident_dry_run_result`

and 

- `withdraw_security_incident_markers` — remove-marker tool
- `update_security_incident` — edit severity, confidence, summary, recommended actions, source URLs, etc.
- `resolve_security_incident`
- `archive_security_incident`
- `create_security_incident_update` — add timeline/update messages to an incident
- `get_security_incident_findings` — current fetch surfaces markers/status/org impact but not detailed customer-facing findings
- `suppress_security_incident_finding` — suppress a specific finding