### PR TITLE
Handle timezone-less vulnerability timestamps

### DIFF
--- a/internal/api/vulnerabilities.go
+++ b/internal/api/vulnerabilities.go
@@ -146,15 +146,15 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 						Purl    string `json:"purl"`
 					} `json:"component"`
 					Vuln *struct {
-						ID             string    `json:"id"`
-						VulnID         string    `json:"vulnId"`
-						Desc           string    `json:"desc"`
-						Sev            string    `json:"sev"`
-						CvssScore      float64   `json:"cvssScore"`
-						CvssVector     string    `json:"cvssVector"`
-						Source         string    `json:"source"`
-						PublishedAt    time.Time `json:"publishedAt"`
-						LastModifiedAt time.Time `json:"lastModifiedAt"`
+						ID             string               `json:"id"`
+						VulnID         string               `json:"vulnId"`
+						Desc           string               `json:"desc"`
+						Sev            string               `json:"sev"`
+						CvssScore      float64              `json:"cvssScore"`
+						CvssVector     string               `json:"cvssVector"`
+						Source         string               `json:"source"`
+						PublishedAt    graphql.FlexibleTime `json:"publishedAt"`
+						LastModifiedAt graphql.FlexibleTime `json:"lastModifiedAt"`
 						VulnInfo       *struct {
 							CveID          string   `json:"cveId"`
 							EpssScore      float64  `json:"epssScore"`
@@ -217,8 +217,8 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 				CvssScore:      n.Vuln.CvssScore,
 				CvssVector:     n.Vuln.CvssVector,
 				Source:         n.Vuln.Source,
-				PublishedAt:    n.Vuln.PublishedAt,
-				LastModifiedAt: n.Vuln.LastModifiedAt,
+				PublishedAt:    n.Vuln.PublishedAt.Time,
+				LastModifiedAt: n.Vuln.LastModifiedAt.Time,
 			}
 			if n.Vuln.VulnInfo != nil {
 				cv.Vuln.VulnInfo = &VulnInfo{
@@ -276,16 +276,16 @@ func (c *Client) lookupByUUID(ctx context.Context, id string) (*Vuln, error) {
 
 	var result struct {
 		Vuln struct {
-			ID             string    `json:"id"`
-			VulnID         string    `json:"vulnId"`
-			Desc           string    `json:"desc"`
-			Sev            string    `json:"sev"`
-			CvssScore      float64   `json:"cvssScore"`
-			CvssVector     string    `json:"cvssVector"`
-			Source         string    `json:"source"`
-			PublishedAt    time.Time `json:"publishedAt"`
-			LastModifiedAt time.Time `json:"lastModifiedAt"`
-			UpdatedAt      time.Time `json:"updatedAt"`
+			ID             string               `json:"id"`
+			VulnID         string               `json:"vulnId"`
+			Desc           string               `json:"desc"`
+			Sev            string               `json:"sev"`
+			CvssScore      float64              `json:"cvssScore"`
+			CvssVector     string               `json:"cvssVector"`
+			Source         string               `json:"source"`
+			PublishedAt    graphql.FlexibleTime `json:"publishedAt"`
+			LastModifiedAt graphql.FlexibleTime `json:"lastModifiedAt"`
+			UpdatedAt      time.Time            `json:"updatedAt"`
 			VulnInfo       *struct {
 				ID             string   `json:"id"`
 				CveID          string   `json:"cveId"`
@@ -310,8 +310,8 @@ func (c *Client) lookupByUUID(ctx context.Context, id string) (*Vuln, error) {
 		CvssScore:      result.Vuln.CvssScore,
 		CvssVector:     result.Vuln.CvssVector,
 		Source:         result.Vuln.Source,
-		PublishedAt:    result.Vuln.PublishedAt,
-		LastModifiedAt: result.Vuln.LastModifiedAt,
+		PublishedAt:    result.Vuln.PublishedAt.Time,
+		LastModifiedAt: result.Vuln.LastModifiedAt.Time,
 		UpdatedAt:      result.Vuln.UpdatedAt,
 	}
 
@@ -338,15 +338,15 @@ func (c *Client) lookupByCveID(ctx context.Context, vulnID string) (*Vuln, error
 
 	var result struct {
 		CveLookup *struct {
-			VulnID       string    `json:"vulnId"`
-			Description  string    `json:"description"`
-			Severity     string    `json:"severity"`
-			Published    time.Time `json:"published"`
-			LastModified time.Time `json:"lastModified"`
-			CvssScore    float64   `json:"cvssScore"`
-			CvssVector   string    `json:"cvssVector"`
-			Cwes         []string  `json:"cwes"`
-			Advisories   []string  `json:"advisories"`
+			VulnID       string               `json:"vulnId"`
+			Description  string               `json:"description"`
+			Severity     string               `json:"severity"`
+			Published    graphql.FlexibleTime `json:"published"`
+			LastModified graphql.FlexibleTime `json:"lastModified"`
+			CvssScore    float64              `json:"cvssScore"`
+			CvssVector   string               `json:"cvssVector"`
+			Cwes         []string             `json:"cwes"`
+			Advisories   []string             `json:"advisories"`
 		} `json:"cveLookup"`
 	}
 
@@ -364,8 +364,8 @@ func (c *Client) lookupByCveID(ctx context.Context, vulnID string) (*Vuln, error
 		Severity:       result.CveLookup.Severity,
 		CvssScore:      result.CveLookup.CvssScore,
 		CvssVector:     result.CveLookup.CvssVector,
-		PublishedAt:    result.CveLookup.Published,
-		LastModifiedAt: result.CveLookup.LastModified,
+		PublishedAt:    result.CveLookup.Published.Time,
+		LastModifiedAt: result.CveLookup.LastModified.Time,
 		VulnInfo: &VulnInfo{
 			Cwes:       result.CveLookup.Cwes,
 			Advisories: result.CveLookup.Advisories,

--- a/internal/api/vulnerabilities_test.go
+++ b/internal/api/vulnerabilities_test.go
@@ -17,7 +17,110 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 )
+
+func TestGetVuln_ByCveIDAcceptsTimestampWithoutTimezone(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"cveLookup": {
+					"vulnId": "CVE-2025-32463",
+					"description": "sudo vulnerability",
+					"severity": "high",
+					"published": "2025-06-30T21:15:30.257",
+					"lastModified": "2025-07-01T10:11:12.123",
+					"cvssScore": 9.3,
+					"cvssVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+					"cwes": ["CWE-863"],
+					"advisories": ["https://example.com/advisory"]
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	vuln, err := client.GetVuln(context.Background(), "", "CVE-2025-32463")
+	if err != nil {
+		t.Fatalf("GetVuln returned error: %v", err)
+	}
+
+	wantPublished := time.Date(2025, 6, 30, 21, 15, 30, 257000000, time.UTC)
+	if !vuln.PublishedAt.Equal(wantPublished) {
+		t.Fatalf("PublishedAt = %s, want %s", vuln.PublishedAt, wantPublished)
+	}
+	if vuln.VulnID != "CVE-2025-32463" || vuln.Severity != "high" {
+		t.Fatalf("unexpected vulnerability: %#v", vuln)
+	}
+}
+
+func TestListVersionVulns_AcceptsNestedVulnTimestampsWithoutTimezone(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"sbom": {
+					"vulns": {
+						"nodes": [
+							{
+								"id": "component-vuln-1",
+								"componentId": "component-1",
+								"vulnId": "vuln-1",
+								"sbomId": "version-1",
+								"fixedIn": "",
+								"fixedVersions": [],
+								"detail": "",
+								"impact": "",
+								"actionStmt": "",
+								"createdAt": "2026-04-16T23:00:09Z",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"component": null,
+								"vuln": {
+									"id": "vuln-1",
+									"vulnId": "CVE-2025-32463",
+									"desc": "sudo vulnerability",
+									"sev": "high",
+									"cvssScore": 9.3,
+									"cvssVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+									"source": "nvd",
+									"publishedAt": "2025-06-30T21:15:30.257",
+									"lastModifiedAt": "2025-07-01T10:11:12.123",
+									"vulnInfo": {
+										"cveId": "CVE-2025-32463",
+										"epssScore": 0.1,
+										"epssPercentile": 0.2,
+										"kev": false,
+										"cwes": ["CWE-863"]
+									}
+								},
+								"vexStatus": null,
+								"vexJustification": null
+							}
+						],
+						"totalCount": 1,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListVersionVulns(context.Background(), ListVersionVulnsInput{VersionID: "version-1"})
+	if err != nil {
+		t.Fatalf("ListVersionVulns returned error: %v", err)
+	}
+
+	if len(result.ComponentVulns) != 1 {
+		t.Fatalf("len(ComponentVulns) = %d, want 1", len(result.ComponentVulns))
+	}
+	wantPublished := time.Date(2025, 6, 30, 21, 15, 30, 257000000, time.UTC)
+	if !result.ComponentVulns[0].Vuln.PublishedAt.Equal(wantPublished) {
+		t.Fatalf("PublishedAt = %s, want %s", result.ComponentVulns[0].Vuln.PublishedAt, wantPublished)
+	}
+}
 
 func TestGetVexStatuses(t *testing.T) {
 	gql := &fakeGraphQLExecutor{


### PR DESCRIPTION
## Summary
- use the existing FlexibleTime parser for vulnerability published/last-modified fields
- cover CVE lookup and nested version vulnerability lookup with timezone-less fractional timestamps
- fixes #31

## Validation
- go test ./internal/api
- go test ./internal/graphql
- make test