### PR TITLE
Add ticketing status visibility tool

### DIFF
--- a/internal/api/policies.go
+++ b/internal/api/policies.go
@@ -23,13 +23,14 @@ import (
 
 // Policy represents a security policy
 type Policy struct {
-	ID          string
-	Name        string
-	Description string
-	Enabled     bool
-	ResultType  string
-	UpdatedAt   time.Time
-	PolicyRules []PolicyRule
+	ID           string
+	Name         string
+	Description  string
+	Enabled      bool
+	ResultType   string
+	CreateTicket bool
+	UpdatedAt    time.Time
+	PolicyRules  []PolicyRule
 }
 
 // PolicyRule represents a rule within a policy
@@ -91,6 +92,155 @@ type LicensesResult struct {
 	EndCursor   string
 }
 
+// TicketingStatusInput contains parameters for fetching ticketing visibility.
+type TicketingStatusInput struct {
+	ProductID     string
+	ProductsFirst int
+	PoliciesFirst int
+	TicketsFirst  int
+}
+
+// TicketingStatus contains ticketing provider configuration and policy application details.
+type TicketingStatus struct {
+	Connections              []TicketingConnectionStatus
+	JiraVulnManagementConfig *JiraVulnManagementConfig
+	Products                 []TicketingProduct
+	Policies                 []TicketingPolicy
+	CreatedTickets           []CreatedTicket
+	ProductsTotalCount       int
+	ProductsHasNextPage      bool
+	PoliciesTotalCount       int
+	PoliciesHasNextPage      bool
+	TicketsScannedCount      int
+	TicketsHasNextPage       bool
+}
+
+// TicketingConnectionStatus contains organization-level ticketing provider connection health.
+type TicketingConnectionStatus struct {
+	Provider          string
+	ConnectionID      string
+	ProviderID        string
+	Enabled           bool
+	URL               string
+	UserName          string
+	HealthCheckStatus string
+	LastHealthCheckAt time.Time
+	UpdatedAt         time.Time
+}
+
+// JiraVulnManagementConfig contains Jira vulnerability-management provisioning status.
+type JiraVulnManagementConfig struct {
+	ID                 string
+	Enabled            bool
+	ProvisioningStatus string
+	ProvisioningStep   string
+	ProvisioningErrors string
+	IssueTypeID        string
+	WorkflowID         string
+	ScreenID           string
+	UpdatedAt          time.Time
+}
+
+// TicketingProduct contains repository and environment ticketing settings for a product.
+type TicketingProduct struct {
+	ID           string
+	Name         string
+	Enabled      bool
+	Repository   *ImportedRepository
+	Environments []TicketingEnvironment
+}
+
+// ImportedRepository contains source-control repository import status for a product.
+type ImportedRepository struct {
+	Type           string
+	ID             string
+	Name           string
+	FullName       string
+	Owner          string
+	DefaultBranch  string
+	Slug           string
+	Workspace      string
+	FullPath       string
+	GitlabID       string
+	ImportStatus   string
+	WebhookEnabled bool
+}
+
+// TicketingEnvironment contains Jira sync settings for one environment.
+type TicketingEnvironment struct {
+	ID                    string
+	Name                  string
+	Enabled               bool
+	IssueTrackerSettings  []ExternalIssueTrackerSetting
+	AppliedTicketPolicies []TicketingPolicySummary
+}
+
+// ExternalIssueTrackerSetting contains per-environment issue tracker configuration.
+type ExternalIssueTrackerSetting struct {
+	ID             string
+	Provider       string
+	ProjectKey     string
+	IssueType      string
+	Assignee       string
+	Reporter       string
+	Epic           string
+	Components     interface{}
+	TeamID         string
+	StateID        string
+	EnableSync     bool
+	LastSyncedAt   time.Time
+	LastSyncStatus string
+	UpdatedAt      time.Time
+}
+
+// TicketingPolicy contains policy ticketing status and application scope.
+type TicketingPolicy struct {
+	ID           string
+	Name         string
+	Enabled      bool
+	ResultType   string
+	CreateTicket bool
+	Inclusions   []TicketingPolicyInclusion
+}
+
+// TicketingPolicySummary contains compact policy data attached to environments.
+type TicketingPolicySummary struct {
+	ID         string
+	Name       string
+	Enabled    bool
+	ResultType string
+}
+
+// TicketingPolicyInclusion contains an environment included by a policy.
+type TicketingPolicyInclusion struct {
+	EnvironmentID   string
+	EnvironmentName string
+	ProductID       string
+	ProductName     string
+}
+
+// CreatedTicket contains an issue tracker link created for a component vulnerability.
+type CreatedTicket struct {
+	ID               string
+	Provider         string
+	IssueKey         string
+	IssueURL         string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	ComponentVulnID  string
+	ComponentName    string
+	ComponentVersion string
+	VulnID           string
+	VulnerabilityID  string
+	Severity         string
+	VersionID        string
+	Version          string
+	EnvironmentID    string
+	EnvironmentName  string
+	ProductID        string
+	ProductName      string
+}
+
 // ListPoliciesInput contains parameters for listing policies
 type ListPoliciesInput struct {
 	First  int
@@ -116,12 +266,13 @@ func (c *Client) ListPolicies(ctx context.Context, input ListPoliciesInput) (*Po
 	var result struct {
 		Policies struct {
 			Nodes []struct {
-				ID          string    `json:"id"`
-				Name        string    `json:"name"`
-				Description string    `json:"description"`
-				Enabled     bool      `json:"isEnabled"`
-				ResultType  string    `json:"resultType"`
-				UpdatedAt   time.Time `json:"updatedAt"`
+				ID           string    `json:"id"`
+				Name         string    `json:"name"`
+				Description  string    `json:"description"`
+				Enabled      bool      `json:"isEnabled"`
+				ResultType   string    `json:"resultType"`
+				CreateTicket bool      `json:"createTicket"`
+				UpdatedAt    time.Time `json:"updatedAt"`
 			} `json:"nodes"`
 			TotalCount int `json:"totalCount"`
 			PageInfo   struct {
@@ -138,12 +289,13 @@ func (c *Client) ListPolicies(ctx context.Context, input ListPoliciesInput) (*Po
 	policies := make([]Policy, len(result.Policies.Nodes))
 	for i, n := range result.Policies.Nodes {
 		policies[i] = Policy{
-			ID:          n.ID,
-			Name:        n.Name,
-			Description: n.Description,
-			Enabled:     n.Enabled,
-			ResultType:  n.ResultType,
-			UpdatedAt:   n.UpdatedAt,
+			ID:           n.ID,
+			Name:         n.Name,
+			Description:  n.Description,
+			Enabled:      n.Enabled,
+			ResultType:   n.ResultType,
+			CreateTicket: n.CreateTicket,
+			UpdatedAt:    n.UpdatedAt,
 		}
 	}
 
@@ -163,13 +315,14 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 
 	var result struct {
 		Policy struct {
-			ID          string    `json:"id"`
-			Name        string    `json:"name"`
-			Description string    `json:"description"`
-			Enabled     bool      `json:"isEnabled"`
-			ResultType  string    `json:"resultType"`
-			UpdatedAt   time.Time `json:"updatedAt"`
-			PolicyRules []struct {
+			ID           string    `json:"id"`
+			Name         string    `json:"name"`
+			Description  string    `json:"description"`
+			Enabled      bool      `json:"isEnabled"`
+			ResultType   string    `json:"resultType"`
+			CreateTicket bool      `json:"createTicket"`
+			UpdatedAt    time.Time `json:"updatedAt"`
+			PolicyRules  []struct {
 				ID       string `json:"id"`
 				Name     string `json:"name"`
 				Subject  string `json:"subject"`
@@ -195,13 +348,14 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	}
 
 	return &Policy{
-		ID:          result.Policy.ID,
-		Name:        result.Policy.Name,
-		Description: result.Policy.Description,
-		Enabled:     result.Policy.Enabled,
-		ResultType:  result.Policy.ResultType,
-		UpdatedAt:   result.Policy.UpdatedAt,
-		PolicyRules: rules,
+		ID:           result.Policy.ID,
+		Name:         result.Policy.Name,
+		Description:  result.Policy.Description,
+		Enabled:      result.Policy.Enabled,
+		ResultType:   result.Policy.ResultType,
+		CreateTicket: result.Policy.CreateTicket,
+		UpdatedAt:    result.Policy.UpdatedAt,
+		PolicyRules:  rules,
 	}, nil
 }
 
@@ -304,6 +458,423 @@ func (c *Client) ListPolicyResults(ctx context.Context, input ListPolicyResultsI
 		HasNextPage:   result.PolicyResults.PageInfo.HasNextPage,
 		EndCursor:     result.PolicyResults.PageInfo.EndCursor,
 	}, nil
+}
+
+// GetTicketingStatus fetches Jira and ticketing policy application status.
+func (c *Client) GetTicketingStatus(ctx context.Context, input TicketingStatusInput) (*TicketingStatus, error) {
+	vars := map[string]interface{}{
+		"policiesFirst": defaultPositive(input.PoliciesFirst, 50),
+		"ticketsFirst":  defaultPositive(input.TicketsFirst, 500),
+	}
+	query := graphql.TicketingStatusQuery
+	if input.ProductID != "" {
+		query = graphql.ProductTicketingStatusQuery
+		vars["productId"] = input.ProductID
+	} else {
+		vars["productsFirst"] = defaultPositive(input.ProductsFirst, 20)
+	}
+
+	var result struct {
+		Organization struct {
+			Connections struct {
+				Nodes []ticketingConnectionNode `json:"nodes"`
+			} `json:"connections"`
+			ProjectGroups struct {
+				Nodes      []ticketingProductNode `json:"nodes"`
+				TotalCount int                    `json:"totalCount"`
+				PageInfo   struct {
+					HasNextPage bool `json:"hasNextPage"`
+				} `json:"pageInfo"`
+			} `json:"projectGroups"`
+		} `json:"organization"`
+		JiraVulnManagementConfig *ticketingJiraConfigNode `json:"jiraVulnManagementConfig"`
+		ProjectGroup             *ticketingProductNode    `json:"projectGroup"`
+		ComponentVulns           ticketingComponentVulns  `json:"componentVulns"`
+		Policies                 struct {
+			Nodes      []ticketingPolicyNode `json:"nodes"`
+			TotalCount int                   `json:"totalCount"`
+			PageInfo   struct {
+				HasNextPage bool `json:"hasNextPage"`
+			} `json:"pageInfo"`
+		} `json:"policies"`
+	}
+
+	if err := c.gql.Execute(ctx, query, vars, &result); err != nil {
+		return nil, err
+	}
+
+	status := &TicketingStatus{
+		Connections:         mapTicketingConnections(result.Organization.Connections.Nodes),
+		ProductsTotalCount:  result.Organization.ProjectGroups.TotalCount,
+		ProductsHasNextPage: result.Organization.ProjectGroups.PageInfo.HasNextPage,
+		PoliciesTotalCount:  result.Policies.TotalCount,
+		PoliciesHasNextPage: result.Policies.PageInfo.HasNextPage,
+	}
+	if result.JiraVulnManagementConfig != nil {
+		status.JiraVulnManagementConfig = mapJiraConfig(*result.JiraVulnManagementConfig)
+	}
+
+	productNodes := result.Organization.ProjectGroups.Nodes
+	if input.ProductID != "" && result.ProjectGroup != nil {
+		productNodes = []ticketingProductNode{*result.ProjectGroup}
+		status.ProductsTotalCount = len(productNodes)
+		status.ProductsHasNextPage = false
+		status.CreatedTickets = mapCreatedTickets(result.ProjectGroup.ComponentVulns.Nodes)
+		status.TicketsScannedCount = result.ProjectGroup.ComponentVulns.TotalCount
+		status.TicketsHasNextPage = result.ProjectGroup.ComponentVulns.PageInfo.HasNextPage
+	} else {
+		status.CreatedTickets = mapCreatedTickets(result.ComponentVulns.Nodes)
+		status.TicketsScannedCount = result.ComponentVulns.TotalCount
+		status.TicketsHasNextPage = result.ComponentVulns.PageInfo.HasNextPage
+	}
+
+	productIDs := make(map[string]bool, len(productNodes))
+	environmentPolicies := make(map[string][]TicketingPolicySummary)
+	for _, product := range productNodes {
+		productIDs[product.ID] = true
+	}
+
+	status.Policies = mapTicketingPolicies(result.Policies.Nodes, productIDs, input.ProductID != "", environmentPolicies)
+	status.Products = mapTicketingProducts(productNodes, environmentPolicies)
+
+	return status, nil
+}
+
+type ticketingConnectionNode struct {
+	ID         string    `json:"id"`
+	Enabled    bool      `json:"enabled"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+	Connection struct {
+		Type              string    `json:"__typename"`
+		ID                string    `json:"id"`
+		URL               string    `json:"url"`
+		UserName          string    `json:"userName"`
+		HealthCheckStatus string    `json:"healthCheckStatus"`
+		LastHealthCheckAt time.Time `json:"lastHealthCheckAt"`
+		UpdatedAt         time.Time `json:"updatedAt"`
+	} `json:"connection"`
+}
+
+type ticketingJiraConfigNode struct {
+	ID                 string    `json:"id"`
+	Enabled            bool      `json:"enabled"`
+	ProvisioningStatus string    `json:"provisioningStatus"`
+	ProvisioningStep   string    `json:"provisioningStep"`
+	ProvisioningErrors string    `json:"provisioningErrors"`
+	IssueTypeID        string    `json:"issueTypeId"`
+	WorkflowID         string    `json:"workflowId"`
+	ScreenID           string    `json:"screenId"`
+	UpdatedAt          time.Time `json:"updatedAt"`
+}
+
+type ticketingProductNode struct {
+	ID                 string                   `json:"id"`
+	Name               string                   `json:"name"`
+	Enabled            bool                     `json:"enabled"`
+	ImportedRepository *ticketingRepositoryNode `json:"importedRepository"`
+	Projects           struct {
+		Nodes []ticketingEnvironmentNode `json:"nodes"`
+	} `json:"projects"`
+	ComponentVulns ticketingComponentVulns `json:"componentVulns"`
+}
+
+type ticketingComponentVulns struct {
+	Nodes      []ticketingComponentVulnNode `json:"nodes"`
+	TotalCount int                          `json:"totalCount"`
+	PageInfo   struct {
+		HasNextPage bool `json:"hasNextPage"`
+	} `json:"pageInfo"`
+}
+
+type ticketingComponentVulnNode struct {
+	ID        string `json:"id"`
+	Component *struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		SbomID  string `json:"sbomId"`
+		Sbom    *struct {
+			ID             string `json:"id"`
+			ProjectVersion string `json:"projectVersion"`
+			Project        *struct {
+				ID           string `json:"id"`
+				Name         string `json:"name"`
+				ProjectGroup *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"projectGroup"`
+			} `json:"project"`
+		} `json:"sbom"`
+	} `json:"component"`
+	Vuln *struct {
+		ID     string `json:"id"`
+		VulnID string `json:"vulnId"`
+		Sev    string `json:"sev"`
+	} `json:"vuln"`
+	ExternalIssueTrackerLinks []struct {
+		ID        string    `json:"id"`
+		Provider  string    `json:"provider"`
+		IssueKey  string    `json:"issueKey"`
+		IssueURL  string    `json:"issueUrl"`
+		CreatedAt time.Time `json:"createdAt"`
+		UpdatedAt time.Time `json:"updatedAt"`
+	} `json:"externalIssueTrackerLinks"`
+}
+
+type ticketingRepositoryNode struct {
+	Type           string `json:"__typename"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	FullName       string `json:"fullName"`
+	Owner          string `json:"owner"`
+	DefaultBranch  string `json:"defaultBranch"`
+	Slug           string `json:"slug"`
+	Workspace      string `json:"workspace"`
+	FullPath       string `json:"fullPath"`
+	GitlabID       string `json:"gitlabId"`
+	ImportStatus   string `json:"importStatus"`
+	WebhookEnabled bool   `json:"webhookEnabled"`
+}
+
+type ticketingEnvironmentNode struct {
+	ID                           string `json:"id"`
+	Name                         string `json:"name"`
+	Enabled                      bool   `json:"enabled"`
+	ExternalIssueTrackerSettings []struct {
+		ID             string      `json:"id"`
+		Provider       string      `json:"provider"`
+		ProjectKey     string      `json:"projectKey"`
+		IssueType      string      `json:"issueType"`
+		Assignee       string      `json:"assignee"`
+		Reporter       string      `json:"reporter"`
+		Epic           string      `json:"epic"`
+		Components     interface{} `json:"components"`
+		TeamID         string      `json:"teamId"`
+		StateID        string      `json:"stateId"`
+		EnableJiraSync bool        `json:"enableJiraSync"`
+		LastSyncedAt   time.Time   `json:"lastSyncedAt"`
+		LastSyncStatus string      `json:"lastSyncStatus"`
+		UpdatedAt      time.Time   `json:"updatedAt"`
+	} `json:"externalIssueTrackerSettings"`
+}
+
+type ticketingPolicyNode struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Enabled          bool   `json:"isEnabled"`
+	ResultType       string `json:"resultType"`
+	CreateTicket     bool   `json:"createTicket"`
+	PolicyInclusions []struct {
+		ProjectID string `json:"projectId"`
+		Project   struct {
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ProjectGroup struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"projectGroup"`
+		} `json:"project"`
+	} `json:"policyInclusions"`
+}
+
+func defaultPositive(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}
+
+func mapTicketingConnections(nodes []ticketingConnectionNode) []TicketingConnectionStatus {
+	connections := make([]TicketingConnectionStatus, 0, len(nodes))
+	for _, node := range nodes {
+		provider := ticketingProviderFromType(node.Connection.Type)
+		if provider == "" {
+			continue
+		}
+		connections = append(connections, TicketingConnectionStatus{
+			Provider:          provider,
+			ConnectionID:      node.ID,
+			ProviderID:        node.Connection.ID,
+			Enabled:           node.Enabled,
+			URL:               node.Connection.URL,
+			UserName:          node.Connection.UserName,
+			HealthCheckStatus: node.Connection.HealthCheckStatus,
+			LastHealthCheckAt: node.Connection.LastHealthCheckAt,
+			UpdatedAt:         node.Connection.UpdatedAt,
+		})
+	}
+	return connections
+}
+
+func ticketingProviderFromType(typeName string) string {
+	switch typeName {
+	case "JiraConnection":
+		return "jira"
+	case "LinearConnection":
+		return "linear"
+	default:
+		return ""
+	}
+}
+
+func mapJiraConfig(node ticketingJiraConfigNode) *JiraVulnManagementConfig {
+	return &JiraVulnManagementConfig{
+		ID:                 node.ID,
+		Enabled:            node.Enabled,
+		ProvisioningStatus: node.ProvisioningStatus,
+		ProvisioningStep:   node.ProvisioningStep,
+		ProvisioningErrors: node.ProvisioningErrors,
+		IssueTypeID:        node.IssueTypeID,
+		WorkflowID:         node.WorkflowID,
+		ScreenID:           node.ScreenID,
+		UpdatedAt:          node.UpdatedAt,
+	}
+}
+
+func mapTicketingPolicies(nodes []ticketingPolicyNode, productIDs map[string]bool, filterByProduct bool, environmentPolicies map[string][]TicketingPolicySummary) []TicketingPolicy {
+	policies := make([]TicketingPolicy, 0, len(nodes))
+	for _, node := range nodes {
+		policy := TicketingPolicy{
+			ID:           node.ID,
+			Name:         node.Name,
+			Enabled:      node.Enabled,
+			ResultType:   node.ResultType,
+			CreateTicket: node.CreateTicket,
+		}
+		summary := TicketingPolicySummary{
+			ID:         node.ID,
+			Name:       node.Name,
+			Enabled:    node.Enabled,
+			ResultType: node.ResultType,
+		}
+
+		for _, inclusion := range node.PolicyInclusions {
+			productID := inclusion.Project.ProjectGroup.ID
+			if filterByProduct && !productIDs[productID] {
+				continue
+			}
+
+			policy.Inclusions = append(policy.Inclusions, TicketingPolicyInclusion{
+				EnvironmentID:   inclusion.ProjectID,
+				EnvironmentName: inclusion.Project.Name,
+				ProductID:       productID,
+				ProductName:     inclusion.Project.ProjectGroup.Name,
+			})
+			if node.CreateTicket {
+				environmentPolicies[inclusion.ProjectID] = append(environmentPolicies[inclusion.ProjectID], summary)
+			}
+		}
+
+		if !filterByProduct || len(policy.Inclusions) > 0 {
+			policies = append(policies, policy)
+		}
+	}
+	return policies
+}
+
+func mapTicketingProducts(nodes []ticketingProductNode, environmentPolicies map[string][]TicketingPolicySummary) []TicketingProduct {
+	products := make([]TicketingProduct, len(nodes))
+	for i, node := range nodes {
+		product := TicketingProduct{
+			ID:      node.ID,
+			Name:    node.Name,
+			Enabled: node.Enabled,
+		}
+		if node.ImportedRepository != nil {
+			product.Repository = &ImportedRepository{
+				Type:           node.ImportedRepository.Type,
+				ID:             node.ImportedRepository.ID,
+				Name:           node.ImportedRepository.Name,
+				FullName:       node.ImportedRepository.FullName,
+				Owner:          node.ImportedRepository.Owner,
+				DefaultBranch:  node.ImportedRepository.DefaultBranch,
+				Slug:           node.ImportedRepository.Slug,
+				Workspace:      node.ImportedRepository.Workspace,
+				FullPath:       node.ImportedRepository.FullPath,
+				GitlabID:       node.ImportedRepository.GitlabID,
+				ImportStatus:   node.ImportedRepository.ImportStatus,
+				WebhookEnabled: node.ImportedRepository.WebhookEnabled,
+			}
+		}
+
+		product.Environments = make([]TicketingEnvironment, len(node.Projects.Nodes))
+		for j, envNode := range node.Projects.Nodes {
+			env := TicketingEnvironment{
+				ID:                    envNode.ID,
+				Name:                  envNode.Name,
+				Enabled:               envNode.Enabled,
+				AppliedTicketPolicies: environmentPolicies[envNode.ID],
+			}
+			for _, setting := range envNode.ExternalIssueTrackerSettings {
+				env.IssueTrackerSettings = append(env.IssueTrackerSettings, ExternalIssueTrackerSetting{
+					ID:             setting.ID,
+					Provider:       setting.Provider,
+					ProjectKey:     setting.ProjectKey,
+					IssueType:      setting.IssueType,
+					Assignee:       setting.Assignee,
+					Reporter:       setting.Reporter,
+					Epic:           setting.Epic,
+					Components:     setting.Components,
+					TeamID:         setting.TeamID,
+					StateID:        setting.StateID,
+					EnableSync:     setting.EnableJiraSync,
+					LastSyncedAt:   setting.LastSyncedAt,
+					LastSyncStatus: setting.LastSyncStatus,
+					UpdatedAt:      setting.UpdatedAt,
+				})
+			}
+			product.Environments[j] = env
+		}
+		products[i] = product
+	}
+	return products
+}
+
+func mapCreatedTickets(nodes []ticketingComponentVulnNode) []CreatedTicket {
+	tickets := []CreatedTicket{}
+	for _, node := range nodes {
+		if len(node.ExternalIssueTrackerLinks) == 0 {
+			continue
+		}
+
+		base := CreatedTicket{
+			ComponentVulnID: node.ID,
+		}
+		if node.Component != nil {
+			base.ComponentName = node.Component.Name
+			base.ComponentVersion = node.Component.Version
+			base.VersionID = node.Component.SbomID
+			if node.Component.Sbom != nil {
+				base.VersionID = node.Component.Sbom.ID
+				base.Version = node.Component.Sbom.ProjectVersion
+				if node.Component.Sbom.Project != nil {
+					base.EnvironmentID = node.Component.Sbom.Project.ID
+					base.EnvironmentName = node.Component.Sbom.Project.Name
+					if node.Component.Sbom.Project.ProjectGroup != nil {
+						base.ProductID = node.Component.Sbom.Project.ProjectGroup.ID
+						base.ProductName = node.Component.Sbom.Project.ProjectGroup.Name
+					}
+				}
+			}
+		}
+		if node.Vuln != nil {
+			base.VulnerabilityID = node.Vuln.ID
+			base.VulnID = node.Vuln.VulnID
+			base.Severity = node.Vuln.Sev
+		}
+
+		for _, link := range node.ExternalIssueTrackerLinks {
+			ticket := base
+			ticket.ID = link.ID
+			ticket.Provider = link.Provider
+			ticket.IssueKey = link.IssueKey
+			ticket.IssueURL = link.IssueURL
+			ticket.CreatedAt = link.CreatedAt
+			ticket.UpdatedAt = link.UpdatedAt
+			tickets = append(tickets, ticket)
+		}
+	}
+	return tickets
 }
 
 // ListLicensesInput contains parameters for listing licenses

--- a/internal/api/policies_test.go
+++ b/internal/api/policies_test.go
@@ -1,0 +1,296 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetTicketingStatus_MapsJiraConfigProductsAndPolicies(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"organization": {
+					"connections": {
+						"nodes": [
+							{
+								"id": "connection-1",
+								"enabled": true,
+								"createdAt": "2026-04-16T23:00:09Z",
+								"updatedAt": "2026-04-16T23:00:10Z",
+								"connection": {
+									"__typename": "JiraConnection",
+									"id": "jira-1",
+									"url": "https://example.atlassian.net",
+									"userName": "bot@example.com",
+									"healthCheckStatus": "Success",
+									"lastHealthCheckAt": "2026-04-17T23:00:10Z",
+									"updatedAt": "2026-04-16T23:00:10Z"
+								}
+							},
+							{
+								"id": "connection-2",
+								"enabled": true,
+								"createdAt": "2026-04-16T23:00:09Z",
+								"updatedAt": "2026-04-16T23:00:10Z",
+								"connection": {
+									"__typename": "LinearConnection",
+									"id": "linear-1",
+									"url": "https://api.linear.app/graphql",
+									"updatedAt": "2026-04-16T23:00:10Z"
+								}
+							}
+						]
+					},
+					"projectGroups": {
+						"nodes": [
+							{
+								"id": "product-1",
+								"name": "Product 1",
+								"enabled": true,
+								"importedRepository": {
+									"__typename": "GithubRepository",
+									"id": "repo-1",
+									"name": "repo",
+									"fullName": "org/repo",
+									"owner": "org",
+									"defaultBranch": "main",
+									"importStatus": "completed",
+									"webhookEnabled": true
+								},
+								"projects": {
+									"nodes": [
+										{
+											"id": "env-1",
+											"name": "default",
+											"enabled": true,
+											"externalIssueTrackerSettings": [
+												{
+													"id": "setting-1",
+													"provider": "jira",
+													"projectKey": "SEC",
+													"issueType": "Task",
+													"assignee": "alice",
+													"reporter": "bot",
+													"epic": "SEC-1",
+													"components": ["backend"],
+													"teamId": "",
+													"stateId": "",
+													"enableJiraSync": true,
+													"lastSyncedAt": "2026-04-18T23:00:10Z",
+													"lastSyncStatus": "success",
+													"updatedAt": "2026-04-18T23:00:10Z"
+												},
+												{
+													"id": "setting-2",
+													"provider": "linear",
+													"projectKey": "",
+													"issueType": "Issue",
+													"assignee": "",
+													"reporter": "",
+													"epic": "",
+													"components": null,
+													"teamId": "team-1",
+													"stateId": "state-1",
+													"enableJiraSync": false,
+													"lastSyncedAt": null,
+													"lastSyncStatus": "",
+													"updatedAt": "2026-04-18T23:00:10Z"
+												}
+											]
+										}
+									]
+								}
+							}
+						],
+						"totalCount": 1,
+						"pageInfo": {
+							"hasNextPage": false
+						}
+					}
+				},
+				"jiraVulnManagementConfig": {
+					"id": "config-1",
+					"enabled": true,
+					"provisioningStatus": "completed",
+					"provisioningStep": "",
+					"provisioningErrors": "",
+					"issueTypeId": "10001",
+					"workflowId": "wf-1",
+					"screenId": "screen-1",
+					"updatedAt": "2026-04-18T23:00:10Z"
+				},
+				"policies": {
+					"nodes": [
+						{
+							"id": "policy-1",
+							"name": "High vulns",
+							"isEnabled": true,
+							"resultType": "fail",
+							"createTicket": true,
+							"policyInclusions": [
+								{
+									"projectId": "env-1",
+									"project": {
+										"id": "env-1",
+										"name": "default",
+										"projectGroup": {
+											"id": "product-1",
+											"name": "Product 1"
+										}
+									}
+								}
+							]
+						}
+					],
+					"totalCount": 1,
+					"pageInfo": {
+						"hasNextPage": false
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	status, err := client.GetTicketingStatus(context.Background(), TicketingStatusInput{ProductsFirst: 5, PoliciesFirst: 10})
+	if err != nil {
+		t.Fatalf("GetTicketingStatus returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["productsFirst"] != 5 || request["policiesFirst"] != 10 {
+		t.Fatalf("unexpected variables: %#v", request)
+	}
+	if len(status.Connections) != 2 {
+		t.Fatalf("len(Connections) = %d, want 2", len(status.Connections))
+	}
+	if status.Connections[0].Provider != "jira" || status.Connections[0].HealthCheckStatus != "Success" {
+		t.Fatalf("unexpected Jira connection: %#v", status.Connections[0])
+	}
+	if status.Connections[1].Provider != "linear" || status.Connections[1].ProviderID != "linear-1" {
+		t.Fatalf("unexpected Linear connection: %#v", status.Connections[1])
+	}
+	if status.JiraVulnManagementConfig == nil || status.JiraVulnManagementConfig.ProvisioningStatus != "completed" {
+		t.Fatalf("unexpected Jira config: %#v", status.JiraVulnManagementConfig)
+	}
+	if len(status.Products) != 1 || status.Products[0].Repository.FullName != "org/repo" {
+		t.Fatalf("unexpected products: %#v", status.Products)
+	}
+	env := status.Products[0].Environments[0]
+	if len(env.IssueTrackerSettings) != 2 {
+		t.Fatalf("len(IssueTrackerSettings) = %d, want 2", len(env.IssueTrackerSettings))
+	}
+	if env.IssueTrackerSettings[0].Provider != "jira" || !env.IssueTrackerSettings[0].EnableSync {
+		t.Fatalf("unexpected Jira settings: %#v", env.IssueTrackerSettings[0])
+	}
+	if env.IssueTrackerSettings[1].Provider != "linear" || env.IssueTrackerSettings[1].TeamID != "team-1" {
+		t.Fatalf("unexpected Linear settings: %#v", env.IssueTrackerSettings[1])
+	}
+	if len(env.AppliedTicketPolicies) != 1 || env.AppliedTicketPolicies[0].ID != "policy-1" {
+		t.Fatalf("unexpected applied policies: %#v", env.AppliedTicketPolicies)
+	}
+}
+
+func TestGetTicketingStatus_ProductFilterKeepsOnlyMatchingPolicyInclusions(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"organization": {
+					"connections": {
+						"nodes": []
+					}
+				},
+				"jiraVulnManagementConfig": null,
+				"projectGroup": {
+					"id": "product-1",
+					"name": "Product 1",
+					"enabled": true,
+					"importedRepository": null,
+					"projects": {
+						"nodes": [
+							{
+								"id": "env-1",
+								"name": "default",
+								"enabled": true,
+								"externalIssueTrackerSettings": []
+							}
+						]
+					}
+				},
+				"policies": {
+					"nodes": [
+						{
+							"id": "policy-1",
+							"name": "Ticket policy",
+							"isEnabled": true,
+							"resultType": "fail",
+							"createTicket": true,
+							"policyInclusions": [
+								{
+									"projectId": "env-1",
+									"project": {
+										"id": "env-1",
+										"name": "default",
+										"projectGroup": {
+											"id": "product-1",
+											"name": "Product 1"
+										}
+									}
+								},
+								{
+									"projectId": "env-2",
+									"project": {
+										"id": "env-2",
+										"name": "staging",
+										"projectGroup": {
+											"id": "product-2",
+											"name": "Product 2"
+										}
+									}
+								}
+							]
+						}
+					],
+					"totalCount": 1,
+					"pageInfo": {
+						"hasNextPage": false
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	status, err := client.GetTicketingStatus(context.Background(), TicketingStatusInput{ProductID: "product-1"})
+	if err != nil {
+		t.Fatalf("GetTicketingStatus returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["productId"] != "product-1" {
+		t.Fatalf("unexpected variables: %#v", request)
+	}
+	if _, ok := request["productsFirst"]; ok {
+		t.Fatalf("productsFirst set for product-specific query: %#v", request)
+	}
+	if len(status.Policies) != 1 {
+		t.Fatalf("len(Policies) = %d, want 1", len(status.Policies))
+	}
+	if len(status.Policies[0].Inclusions) != 1 || status.Policies[0].Inclusions[0].ProductID != "product-1" {
+		t.Fatalf("unexpected inclusions: %#v", status.Policies[0].Inclusions)
+	}
+}

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -490,6 +490,7 @@ const (
 					description
 					isEnabled
 					resultType
+					createTicket
 					updatedAt
 				}
 				totalCount
@@ -512,6 +513,7 @@ const (
 				description
 				isEnabled
 				resultType
+				createTicket
 				updatedAt
 				policyRules {
 					id
@@ -553,6 +555,343 @@ const (
 					hasNextPage
 					hasPreviousPage
 					startCursor
+					endCursor
+				}
+			}
+		}
+	`
+
+	// TicketingStatusQuery fetches Jira configuration and ticketing policy application status.
+	TicketingStatusQuery = `
+		query GetTicketingStatus($productsFirst: Int, $policiesFirst: Int, $ticketsFirst: Int) {
+			organization {
+				connections {
+					nodes {
+						id
+						enabled
+						createdAt
+						updatedAt
+						connection {
+							__typename
+							... on JiraConnection {
+								id
+								url
+								userName
+								healthCheckStatus
+								lastHealthCheckAt
+								updatedAt
+							}
+							... on LinearConnection {
+								id
+								url
+								updatedAt
+							}
+						}
+					}
+				}
+				projectGroups(first: $productsFirst) {
+					nodes {
+						id
+						name
+						enabled
+						importedRepository {
+							__typename
+							... on GithubRepository {
+								id
+								name
+								fullName
+								owner
+								defaultBranch
+								importStatus
+								webhookEnabled
+							}
+							... on BitbucketRepository {
+								id
+								name
+								fullName
+								slug
+								workspace
+								importStatus
+								webhookEnabled
+							}
+							... on GitlabRepository {
+								id
+								name
+								fullPath
+								gitlabId
+								importStatus
+								webhookEnabled
+							}
+						}
+						projects(first: 100) {
+							nodes {
+								id
+								name
+								enabled
+								externalIssueTrackerSettings {
+									id
+									provider
+									projectKey
+									issueType
+									assignee
+									reporter
+									epic
+									components
+									teamId
+									stateId
+									enableJiraSync
+									lastSyncedAt
+									lastSyncStatus
+									updatedAt
+								}
+							}
+						}
+					}
+					totalCount
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+			jiraVulnManagementConfig {
+				id
+				enabled
+				provisioningStatus
+				provisioningStep
+				provisioningErrors
+				issueTypeId
+				workflowId
+				screenId
+				updatedAt
+			}
+			policies(first: $policiesFirst) {
+				nodes {
+					id
+					name
+					isEnabled
+					resultType
+					createTicket
+					policyInclusions {
+						projectId
+						project {
+							id
+							name
+							projectGroup {
+								id
+								name
+							}
+						}
+					}
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+			componentVulns(first: $ticketsFirst) {
+				nodes {
+					id
+					component {
+						name
+						version
+						sbomId
+						sbom {
+							id
+							projectVersion
+							project {
+								id
+								name
+								projectGroup {
+									id
+									name
+								}
+							}
+						}
+					}
+					vuln {
+						id
+						vulnId
+						sev
+					}
+					externalIssueTrackerLinks {
+						id
+						provider
+						issueKey
+						issueUrl
+						createdAt
+						updatedAt
+					}
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	`
+
+	// ProductTicketingStatusQuery fetches ticketing status for one product/repository.
+	ProductTicketingStatusQuery = `
+		query GetProductTicketingStatus($productId: Uuid!, $policiesFirst: Int, $ticketsFirst: Int) {
+			organization {
+				connections {
+					nodes {
+						id
+						enabled
+						createdAt
+						updatedAt
+						connection {
+							__typename
+							... on JiraConnection {
+								id
+								url
+								userName
+								healthCheckStatus
+								lastHealthCheckAt
+								updatedAt
+							}
+							... on LinearConnection {
+								id
+								url
+								updatedAt
+							}
+						}
+					}
+				}
+			}
+			jiraVulnManagementConfig {
+				id
+				enabled
+				provisioningStatus
+				provisioningStep
+				provisioningErrors
+				issueTypeId
+				workflowId
+				screenId
+				updatedAt
+			}
+			projectGroup(id: $productId) {
+				id
+				name
+				enabled
+				importedRepository {
+					__typename
+					... on GithubRepository {
+						id
+						name
+						fullName
+						owner
+						defaultBranch
+						importStatus
+						webhookEnabled
+					}
+					... on BitbucketRepository {
+						id
+						name
+						fullName
+						slug
+						workspace
+						importStatus
+						webhookEnabled
+					}
+					... on GitlabRepository {
+						id
+						name
+						fullPath
+						gitlabId
+						importStatus
+						webhookEnabled
+					}
+				}
+				projects(first: 100) {
+					nodes {
+						id
+						name
+						enabled
+						externalIssueTrackerSettings {
+							id
+							provider
+							projectKey
+							issueType
+							assignee
+							reporter
+							epic
+							components
+							teamId
+							stateId
+							enableJiraSync
+							lastSyncedAt
+							lastSyncStatus
+							updatedAt
+						}
+					}
+				}
+				componentVulns(first: $ticketsFirst) {
+					nodes {
+						id
+						component {
+							name
+							version
+							sbomId
+							sbom {
+								id
+								projectVersion
+								project {
+									id
+									name
+									projectGroup {
+										id
+										name
+									}
+								}
+							}
+						}
+						vuln {
+							id
+							vulnId
+							sev
+						}
+						externalIssueTrackerLinks {
+							id
+							provider
+							issueKey
+							issueUrl
+							createdAt
+							updatedAt
+						}
+					}
+					totalCount
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+			policies(first: $policiesFirst) {
+				nodes {
+					id
+					name
+					isEnabled
+					resultType
+					createTicket
+					policyInclusions {
+						projectId
+						project {
+							id
+							name
+							projectGroup {
+								id
+								name
+							}
+						}
+					}
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
 					endCursor
 				}
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -268,6 +268,14 @@ func (s *Server) registerTools() {
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
 	), s.handleListPolicyViolations)
 
+	s.mcp.AddTool(mcp.NewTool("get_ticketing_status",
+		mcp.WithDescription("Get ticketing provider connection/config status and policy application for products/repositories"),
+		mcp.WithString("product_id", mcp.Description("Optional product UUID to inspect one product/repository")),
+		mcp.WithNumber("products_limit", mcp.Description("Maximum number of products to inspect when product_id is omitted (default: 20)")),
+		mcp.WithNumber("policies_limit", mcp.Description("Maximum number of policies to inspect (default: 50)")),
+		mcp.WithNumber("ticket_links_limit", mcp.Description("Maximum number of component vulnerabilities to scan for created ticket links (default: 500)")),
+	), s.handleGetTicketingStatus)
+
 	// License tools
 	s.mcp.AddTool(mcp.NewTool("list_licenses",
 		mcp.WithDescription("List licenses used in the organization's versions"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -885,12 +885,13 @@ func (s *Server) handleListPolicies(ctx context.Context, request mcp.CallToolReq
 	policies := make([]map[string]interface{}, len(result.Policies))
 	for i, p := range result.Policies {
 		policies[i] = map[string]interface{}{
-			"id":          p.ID,
-			"name":        p.Name,
-			"description": p.Description,
-			"enabled":     p.Enabled,
-			"resultType":  p.ResultType,
-			"updatedAt":   p.UpdatedAt,
+			"id":           p.ID,
+			"name":         p.Name,
+			"description":  p.Description,
+			"enabled":      p.Enabled,
+			"resultType":   p.ResultType,
+			"createTicket": p.CreateTicket,
+			"updatedAt":    p.UpdatedAt,
 		}
 	}
 
@@ -925,13 +926,14 @@ func (s *Server) handleGetPolicy(ctx context.Context, request mcp.CallToolReques
 	}
 
 	return formatResult(map[string]interface{}{
-		"id":          policy.ID,
-		"name":        policy.Name,
-		"description": policy.Description,
-		"enabled":     policy.Enabled,
-		"resultType":  policy.ResultType,
-		"updatedAt":   policy.UpdatedAt,
-		"rules":       rules,
+		"id":           policy.ID,
+		"name":         policy.Name,
+		"description":  policy.Description,
+		"enabled":      policy.Enabled,
+		"resultType":   policy.ResultType,
+		"createTicket": policy.CreateTicket,
+		"updatedAt":    policy.UpdatedAt,
+		"rules":        rules,
 	})
 }
 
@@ -984,6 +986,25 @@ func (s *Server) handleListPolicyViolations(ctx context.Context, request mcp.Cal
 	})
 }
 
+func (s *Server) handleGetTicketingStatus(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	input := api.TicketingStatusInput{
+		ProductsFirst: getIntParam(args, "products_limit", 20),
+		PoliciesFirst: getIntParam(args, "policies_limit", 50),
+		TicketsFirst:  getIntParam(args, "ticket_links_limit", 500),
+	}
+	if productID, ok := args["product_id"].(string); ok {
+		input.ProductID = productID
+	}
+
+	status, err := s.client.GetTicketingStatus(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get ticketing status: %v", err)), nil
+	}
+
+	return formatResult(formatTicketingStatus(status))
+}
+
 func (s *Server) handleListLicenses(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	input := api.ListLicensesInput{
@@ -1025,6 +1046,203 @@ func (s *Server) handleListLicenses(ctx context.Context, request mcp.CallToolReq
 }
 
 // Helper functions
+
+func formatTicketingStatus(status *api.TicketingStatus) map[string]interface{} {
+	result := map[string]interface{}{
+		"productsTotalCount":  status.ProductsTotalCount,
+		"productsHasMore":     status.ProductsHasNextPage,
+		"policiesTotalCount":  status.PoliciesTotalCount,
+		"policiesHasMore":     status.PoliciesHasNextPage,
+		"ticketsScannedCount": status.TicketsScannedCount,
+		"ticketsHasMore":      status.TicketsHasNextPage,
+	}
+
+	connections := make([]map[string]interface{}, len(status.Connections))
+	for i, connection := range status.Connections {
+		connectionData := map[string]interface{}{
+			"provider":     connection.Provider,
+			"connectionId": connection.ConnectionID,
+			"providerId":   connection.ProviderID,
+			"enabled":      connection.Enabled,
+			"url":          connection.URL,
+			"updatedAt":    connection.UpdatedAt,
+		}
+		if connection.UserName != "" {
+			connectionData["userName"] = connection.UserName
+		}
+		if connection.HealthCheckStatus != "" {
+			connectionData["healthCheckStatus"] = connection.HealthCheckStatus
+		}
+		if !connection.LastHealthCheckAt.IsZero() {
+			connectionData["lastHealthCheckAt"] = connection.LastHealthCheckAt
+		}
+		connections[i] = connectionData
+	}
+	result["ticketingConnections"] = connections
+
+	if status.JiraVulnManagementConfig != nil {
+		result["providerConfigs"] = map[string]interface{}{
+			"jiraVulnManagement": map[string]interface{}{
+				"id":                 status.JiraVulnManagementConfig.ID,
+				"enabled":            status.JiraVulnManagementConfig.Enabled,
+				"provisioningStatus": status.JiraVulnManagementConfig.ProvisioningStatus,
+				"provisioningStep":   status.JiraVulnManagementConfig.ProvisioningStep,
+				"provisioningErrors": status.JiraVulnManagementConfig.ProvisioningErrors,
+				"issueTypeId":        status.JiraVulnManagementConfig.IssueTypeID,
+				"workflowId":         status.JiraVulnManagementConfig.WorkflowID,
+				"screenId":           status.JiraVulnManagementConfig.ScreenID,
+				"updatedAt":          status.JiraVulnManagementConfig.UpdatedAt,
+			},
+		}
+	} else {
+		result["providerConfigs"] = map[string]interface{}{}
+	}
+
+	products := make([]map[string]interface{}, len(status.Products))
+	for i, product := range status.Products {
+		productData := map[string]interface{}{
+			"id":           product.ID,
+			"name":         product.Name,
+			"enabled":      product.Enabled,
+			"repository":   formatImportedRepository(product.Repository),
+			"environments": formatTicketingEnvironments(product.Environments),
+		}
+		products[i] = productData
+	}
+	result["products"] = products
+
+	policies := make([]map[string]interface{}, len(status.Policies))
+	for i, policy := range status.Policies {
+		inclusions := make([]map[string]interface{}, len(policy.Inclusions))
+		for j, inclusion := range policy.Inclusions {
+			inclusions[j] = map[string]interface{}{
+				"environmentId":   inclusion.EnvironmentID,
+				"environmentName": inclusion.EnvironmentName,
+				"productId":       inclusion.ProductID,
+				"productName":     inclusion.ProductName,
+			}
+		}
+		policies[i] = map[string]interface{}{
+			"id":           policy.ID,
+			"name":         policy.Name,
+			"enabled":      policy.Enabled,
+			"resultType":   policy.ResultType,
+			"createTicket": policy.CreateTicket,
+			"inclusions":   inclusions,
+		}
+	}
+	result["policies"] = policies
+	result["createdTickets"] = formatCreatedTickets(status.CreatedTickets)
+
+	return result
+}
+
+func formatCreatedTickets(tickets []api.CreatedTicket) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(tickets))
+	for i, ticket := range tickets {
+		result[i] = map[string]interface{}{
+			"id":               ticket.ID,
+			"provider":         ticket.Provider,
+			"issueKey":         ticket.IssueKey,
+			"issueUrl":         ticket.IssueURL,
+			"createdAt":        ticket.CreatedAt,
+			"updatedAt":        ticket.UpdatedAt,
+			"componentVulnId":  ticket.ComponentVulnID,
+			"componentName":    ticket.ComponentName,
+			"componentVersion": ticket.ComponentVersion,
+			"vulnId":           ticket.VulnID,
+			"vulnerabilityId":  ticket.VulnerabilityID,
+			"severity":         ticket.Severity,
+			"versionId":        ticket.VersionID,
+			"version":          ticket.Version,
+			"environmentId":    ticket.EnvironmentID,
+			"environmentName":  ticket.EnvironmentName,
+			"productId":        ticket.ProductID,
+			"productName":      ticket.ProductName,
+		}
+	}
+	return result
+}
+
+func formatImportedRepository(repo *api.ImportedRepository) interface{} {
+	if repo == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"type":           repo.Type,
+		"id":             repo.ID,
+		"name":           repo.Name,
+		"importStatus":   repo.ImportStatus,
+		"webhookEnabled": repo.WebhookEnabled,
+	}
+	if repo.FullName != "" {
+		data["fullName"] = repo.FullName
+	}
+	if repo.Owner != "" {
+		data["owner"] = repo.Owner
+	}
+	if repo.DefaultBranch != "" {
+		data["defaultBranch"] = repo.DefaultBranch
+	}
+	if repo.Slug != "" {
+		data["slug"] = repo.Slug
+	}
+	if repo.Workspace != "" {
+		data["workspace"] = repo.Workspace
+	}
+	if repo.FullPath != "" {
+		data["fullPath"] = repo.FullPath
+	}
+	if repo.GitlabID != "" {
+		data["gitlabId"] = repo.GitlabID
+	}
+	return data
+}
+
+func formatTicketingEnvironments(environments []api.TicketingEnvironment) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(environments))
+	for i, environment := range environments {
+		settings := make([]map[string]interface{}, len(environment.IssueTrackerSettings))
+		for j, setting := range environment.IssueTrackerSettings {
+			settings[j] = map[string]interface{}{
+				"id":             setting.ID,
+				"provider":       setting.Provider,
+				"projectKey":     setting.ProjectKey,
+				"issueType":      setting.IssueType,
+				"assignee":       setting.Assignee,
+				"reporter":       setting.Reporter,
+				"epic":           setting.Epic,
+				"components":     setting.Components,
+				"teamId":         setting.TeamID,
+				"stateId":        setting.StateID,
+				"enableSync":     setting.EnableSync,
+				"lastSyncedAt":   setting.LastSyncedAt,
+				"lastSyncStatus": setting.LastSyncStatus,
+				"updatedAt":      setting.UpdatedAt,
+			}
+		}
+
+		policies := make([]map[string]interface{}, len(environment.AppliedTicketPolicies))
+		for j, policy := range environment.AppliedTicketPolicies {
+			policies[j] = map[string]interface{}{
+				"id":         policy.ID,
+				"name":       policy.Name,
+				"enabled":    policy.Enabled,
+				"resultType": policy.ResultType,
+			}
+		}
+
+		result[i] = map[string]interface{}{
+			"id":                    environment.ID,
+			"name":                  environment.Name,
+			"enabled":               environment.Enabled,
+			"issueTrackerSettings":  settings,
+			"appliedTicketPolicies": policies,
+		}
+	}
+	return result
+}
 
 // newToolResultError creates a CallToolResult with IsError set to true
 func newToolResultError(message string) *mcp.CallToolResult {


### PR DESCRIPTION
## Summary
- add read-only get_ticketing_status for ticketing provider connection/config status
- report product repository status, environment issue tracker settings, and ticket-enabled policy application
- include read-only created external issue tracker links with provider, issue key, URL, product/environment/version/component/vulnerability context
- include createTicket on policy list/detail responses as status metadata only
- exposes no MCP tool or mutation that creates, syncs, updates, or deletes tickets
- fixes #30

## Validation
- go test ./internal/api ./internal/mcp ./internal/graphql
- make test
- make build

## Live check
- get_ticketing_status returned Jira and Linear org connections
- found read-only Jira createdTickets including LYNKAPI-1145, LYNKAPI-1053, LYNKAPI-1089, LYNKAPI-959, LYNKAPI-1144, LYNKAPI-592, LYNKAPI-1088, LYNKAPI-977, LYNKAPI-594, and LYNKAPI-1175