### PR TITLE
Use zip archives for Windows releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,12 @@ signs:
 
 archives:
   - id: lynk-mcp
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_


### PR DESCRIPTION
## Summary
- Configure GoReleaser to emit .zip archives for Windows builds
- Keep Linux and macOS archives as .tar.gz

## Root Cause
The v0.2.1 release failed in the winget step because GoReleaser could not find a Windows zip archive:

```
no zip archives found matching goos=[windows] goarch=[amd64 386] goamd64=v1 ids=[lynk-mcp]
```

## Validation
- goreleaser check
- goreleaser release --clean --snapshot --skip=publish --skip=sign with dummy release env vars
- Snapshot generated Windows .zip archives and winget manifests successfully