### PR TITLE
Simplify verify command

### DIFF
--- a/cmd/lynk-mcp/main.go
+++ b/cmd/lynk-mcp/main.go
@@ -17,12 +17,10 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/interlynk-io/lynk-mcp/internal/api"
 	"github.com/interlynk-io/lynk-mcp/internal/config"
 	"github.com/interlynk-io/lynk-mcp/internal/mcp"
-	"github.com/interlynk-io/lynk-mcp/internal/retry"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"sigs.k8s.io/release-utils/version"
@@ -136,32 +134,15 @@ func runVerify(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(cfg.API.Endpoint, token, cfg.API.Timeout)
 
-	var org *api.Organization
-	start := time.Now()
-
-	err = retry.Do(cmd.Context(), retry.DefaultVerifyConfig(), func() error {
-		var getErr error
-		org, getErr = client.GetOrganization(cmd.Context())
-		return getErr
-	}, nil, func(attempt int, retryErr error, delay time.Duration) {
-		elapsed := time.Since(start).Truncate(time.Second)
-		fmt.Printf("  Attempt %d failed (%s elapsed): %v\n", attempt, elapsed, retryErr)
-		fmt.Printf("  Token may still be propagating. Retrying in %s...\n", delay.Truncate(time.Second))
-	})
+	org, err := client.GetBasicOrganization(cmd.Context())
 	if err != nil {
-		return fmt.Errorf("failed to connect after %s: %w", time.Since(start).Truncate(time.Second), err)
+		return fmt.Errorf("failed to connect: %w", err)
 	}
 
 	fmt.Println()
 	fmt.Println("Connection successful!")
 	fmt.Println()
 	fmt.Printf("Organization: %s\n", org.Name)
-	fmt.Printf("ID: %s\n", org.ID)
-	if org.Metrics != nil {
-		fmt.Printf("Environments: %d\n", org.Metrics.ProjectCount)
-		fmt.Printf("Versions: %d\n", org.Metrics.VersionCount)
-		fmt.Printf("Components: %d\n", org.Metrics.ComponentCount)
-	}
 
 	return nil
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -57,6 +57,24 @@ type OrganizationMetrics struct {
 	VulnsMetric    map[string]interface{}
 }
 
+// GetBasicOrganization fetches minimal organization information for quick
+// connection checks.
+func (c *Client) GetBasicOrganization(ctx context.Context) (*Organization, error) {
+	var result struct {
+		Organization struct {
+			Name string `json:"name"`
+		} `json:"organization"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.BasicOrganizationQuery, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return &Organization{
+		Name: result.Organization.Name,
+	}, nil
+}
+
 // GetOrganization fetches the current organization information
 func (c *Client) GetOrganization(ctx context.Context) (*Organization, error) {
 	var result struct {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGetBasicOrganization_UsesMinimalQuery(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"organization": {
+					"name": "Interlynk"
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	org, err := client.GetBasicOrganization(context.Background())
+	if err != nil {
+		t.Fatalf("GetBasicOrganization returned error: %v", err)
+	}
+	if org.Name != "Interlynk" {
+		t.Fatalf("Name = %q, want Interlynk", org.Name)
+	}
+
+	query := gql.queries[0]
+	if strings.Contains(query, "organizationMetric") {
+		t.Fatalf("basic organization query should not request metrics: %s", query)
+	}
+	for _, field := range []string{"projectCount", "versionCount", "componentCount"} {
+		if strings.Contains(query, field) {
+			t.Fatalf("basic organization query should not request %s: %s", field, query)
+		}
+	}
+}

--- a/internal/api/products_test.go
+++ b/internal/api/products_test.go
@@ -21,11 +21,13 @@ import (
 )
 
 type fakeGraphQLExecutor struct {
+	queries  []string
 	requests []map[string]interface{}
 	pages    []string
 }
 
 func (f *fakeGraphQLExecutor) Execute(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
+	f.queries = append(f.queries, query)
 	f.requests = append(f.requests, variables)
 	return json.Unmarshal([]byte(f.pages[len(f.requests)-1]), result)
 }

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -17,6 +17,16 @@ package graphql
 // GraphQL query strings for the Lynk API
 
 const (
+	// BasicOrganizationQuery fetches the minimal organization information used
+	// by quick connection checks.
+	BasicOrganizationQuery = `
+		query GetBasicOrganization {
+			organization {
+				name
+			}
+		}
+	`
+
 	// OrganizationQuery fetches organization information with metrics
 	OrganizationQuery = `
 		query GetOrganization {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -23,9 +23,9 @@ import (
 
 // Config controls retry behavior.
 type Config struct {
-	MaxRetries   int
-	InitialDelay time.Duration
-	MaxDelay     time.Duration
+	MaxRetries    int
+	InitialDelay  time.Duration
+	MaxDelay      time.Duration
 	BackoffFactor float64
 }
 
@@ -37,17 +37,6 @@ func DefaultTransientConfig() Config {
 		InitialDelay:  1 * time.Second,
 		MaxDelay:      10 * time.Second,
 		BackoffFactor: 2.0,
-	}
-}
-
-// DefaultVerifyConfig returns a config for the verify command retry loop
-// (24 retries, 10s initial, 15s max, 1.5x backoff, ~6 min total).
-func DefaultVerifyConfig() Config {
-	return Config{
-		MaxRetries:    24,
-		InitialDelay:  10 * time.Second,
-		MaxDelay:      15 * time.Second,
-		BackoffFactor: 1.5,
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the verify-specific long retry loop
- add a minimal organization query for verify that only requests the organization name
- keep the richer organization query for MCP tools/resources

## Validation
- GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./internal/api
- GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./cmd/lynk-mcp
- make build