### PR TITLE
Add MCP pagination cursors for products and vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Add to `~/.config/zed/settings.json`:
 | `list_environments` | List environments within a product |
 | `get_environment` | Get details of a specific environment |
 
+`list_products` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.
+
 ### Versions, SBOM Doctor & Components
 
 | Tool | Description |
@@ -360,6 +362,8 @@ Add to `~/.config/zed/settings.json`:
 | `list_vex_justifications` | List VEX justifications with UUIDs for CVE triage |
 | `update_component_vex` | Update VEX data for a component vulnerability; requires `confirm=true` |
 | `search_vulnerabilities` | Search across all products |
+
+`list_vulnerabilities` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.
 
 ### Supply-Chain Security Incidents
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -247,6 +247,7 @@ func (s *Server) registerTools() {
 		mcp.WithBoolean("exceptional", mcp.Description("Shortcut for match_mode=any with cvss_min=9.0, epss_min=0.05, or kev=true")),
 		mcp.WithString("search", mcp.Description("Search term to filter vulnerabilities")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
 	), s.handleListVulnerabilities)
 
 	s.mcp.AddTool(mcp.NewTool("get_vulnerability",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,15 +15,58 @@
 package mcp
 
 import (
+	"context"
+
 	"github.com/interlynk-io/lynk-mcp/internal/api"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 )
 
+type lynkClient interface {
+	GetOrganization(ctx context.Context) (*api.Organization, error)
+	ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error)
+	GetProduct(ctx context.Context, id string) (*api.Product, error)
+	ListVersions(ctx context.Context, input api.ListVersionsInput) (*api.VersionsResult, error)
+	GetVersion(ctx context.Context, id string) (*api.Version, error)
+	ListDoctorResults(ctx context.Context, input api.ListDoctorResultsInput) (*api.DoctorResultsResult, error)
+	CompareVersions(ctx context.Context, sourceVersionID, targetVersionID string) ([]api.VersionDiff, error)
+	ListComponents(ctx context.Context, input api.ListComponentsInput) (*api.ComponentsResult, error)
+	GetComponent(ctx context.Context, id, versionID string) (*api.VersionComponent, error)
+	UpdateComponent(ctx context.Context, input api.UpdateComponentInput) (*api.UpdateComponentResult, error)
+	UpdateComponentSupplier(ctx context.Context, input api.UpdateComponentSupplierInput) (*api.UpdateComponentSupplierResult, error)
+	ListVersionVulns(ctx context.Context, input api.ListVersionVulnsInput) (*api.ComponentVulnsResult, error)
+	GetVuln(ctx context.Context, id, vulnID string) (*api.Vuln, error)
+	GetVexStatuses(ctx context.Context) ([]api.VexStatus, error)
+	GetVexJustifications(ctx context.Context) ([]api.VexJustification, error)
+	UpdateComponentVex(ctx context.Context, input api.UpdateComponentVexInput) (*api.UpdateComponentVexResult, error)
+	ListComponentVulns(ctx context.Context, input api.ListComponentVulnsInput) (*api.ComponentVulnsResult, error)
+	ListSecurityIncidents(ctx context.Context, input api.ListSecurityIncidentsInput) ([]api.SecurityIncident, error)
+	GetSecurityIncident(ctx context.Context, id string) (*api.SecurityIncident, error)
+	CreateSecurityIncident(ctx context.Context, input api.CreateSecurityIncidentInput) (*api.CreateSecurityIncidentResult, error)
+	UpdateSecurityIncident(ctx context.Context, input api.UpdateSecurityIncidentInput) (*api.SecurityIncidentMutationResult, error)
+	GetSecurityIncidentFindings(ctx context.Context, input api.SecurityIncidentFindingsInput) (*api.SecurityIncidentFindingsResult, error)
+	AddSecurityIncidentMarkers(ctx context.Context, incidentID string, markers []api.SecurityIncidentMarkerInput) (*api.AddSecurityIncidentMarkersResult, error)
+	WithdrawSecurityIncidentMarkers(ctx context.Context, incidentID string, markerIDs []string) (*api.SecurityIncidentMarkersResult, error)
+	PublishSecurityIncident(ctx context.Context, id string) (*api.SecurityIncidentMutationResult, error)
+	ResolveSecurityIncident(ctx context.Context, id string) (*api.SecurityIncidentMutationResult, error)
+	ArchiveSecurityIncident(ctx context.Context, id string) (*api.SecurityIncidentMutationResult, error)
+	CreateSecurityIncidentUpdate(ctx context.Context, input api.CreateSecurityIncidentUpdateInput) (*api.CreateSecurityIncidentUpdateResult, error)
+	SuppressSecurityIncidentFinding(ctx context.Context, input api.SuppressSecurityIncidentFindingInput) (*api.SuppressSecurityIncidentFindingResult, error)
+	RerunSecurityIncidentImpactScan(ctx context.Context, id string) (*api.SecurityIncidentMutationResult, error)
+	DryRunSecurityIncidentImpactScan(ctx context.Context, id string) (*api.DryRunSecurityIncidentImpactScanResult, error)
+	GetSecurityIncidentDryRunResult(ctx context.Context, input api.SecurityIncidentDryRunResultInput) (*api.SecurityIncidentDryRunResult, error)
+	ListPolicies(ctx context.Context, input api.ListPoliciesInput) (*api.PoliciesResult, error)
+	GetPolicy(ctx context.Context, id string) (*api.Policy, error)
+	ListPolicyResults(ctx context.Context, input api.ListPolicyResultsInput) (*api.PolicyResultsResult, error)
+	GetTicketingStatus(ctx context.Context, input api.TicketingStatusInput) (*api.TicketingStatus, error)
+	ListLicenses(ctx context.Context, input api.ListLicensesInput) (*api.LicensesResult, error)
+	GetEnvironment(ctx context.Context, id string) (*api.Environment, error)
+}
+
 // Server is the MCP server for Lynk API
 type Server struct {
-	client *api.Client
+	client lynkClient
 	logger *zap.Logger
 	mcp    *server.MCPServer
 }
@@ -67,6 +110,7 @@ func (s *Server) registerTools() {
 		mcp.WithDescription("List all products in the organization"),
 		mcp.WithString("search", mcp.Description("Search term to filter by name")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 20)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
 	), s.handleListProducts)
 
 	s.mcp.AddTool(mcp.NewTool("get_product",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -610,6 +610,9 @@ func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.Call
 	if search, ok := args["search"].(string); ok {
 		input.Search = search
 	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
 
 	var result *api.ComponentVulnsResult
 	var matchReasons map[string][]string
@@ -640,6 +643,7 @@ func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.Call
 		"vulnerabilities": formatComponentVulns(result.ComponentVulns, matchReasons, true),
 		"totalCount":      result.TotalCount,
 		"hasMore":         result.HasNextPage,
+		"endCursor":       result.EndCursor,
 	})
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -62,6 +62,9 @@ func (s *Server) handleListProducts(ctx context.Context, request mcp.CallToolReq
 	if search, ok := args["search"].(string); ok {
 		input.Search = search
 	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
 
 	result, err := s.client.ListProducts(ctx, input)
 	if err != nil {
@@ -84,6 +87,7 @@ func (s *Server) handleListProducts(ctx context.Context, request mcp.CallToolReq
 		"products":   products,
 		"totalCount": result.TotalCount,
 		"hasMore":    result.HasNextPage,
+		"endCursor":  result.EndCursor,
 	})
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -26,7 +26,8 @@ import (
 
 type fakeLynkClient struct {
 	lynkClient
-	listProductsInput api.ListProductsInput
+	listProductsInput     api.ListProductsInput
+	listVersionVulnsInput api.ListVersionVulnsInput
 }
 
 func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error) {
@@ -44,6 +45,31 @@ func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProduct
 		TotalCount:  3,
 		HasNextPage: true,
 		EndCursor:   "cursor-2",
+	}, nil
+}
+
+func (f *fakeLynkClient) ListVersionVulns(ctx context.Context, input api.ListVersionVulnsInput) (*api.ComponentVulnsResult, error) {
+	f.listVersionVulnsInput = input
+	return &api.ComponentVulnsResult{
+		ComponentVulns: []api.ComponentVuln{
+			{
+				ID:        "component-vuln-1",
+				VersionID: input.VersionID,
+				Component: &api.VersionComponent{
+					ID:      "component-1",
+					Name:    "openssl",
+					Version: "3.0.0",
+				},
+				Vuln: &api.Vuln{
+					ID:       "vuln-1",
+					VulnID:   "CVE-2026-0001",
+					Severity: "high",
+				},
+			},
+		},
+		TotalCount:  4,
+		HasNextPage: true,
+		EndCursor:   "vuln-cursor-2",
 	}, nil
 }
 
@@ -79,6 +105,48 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 	output := toolResultMap(t, result)
 	if output["endCursor"] != "cursor-2" {
 		t.Fatalf("endCursor = %#v, want cursor-2", output["endCursor"])
+	}
+	if output["hasMore"] != true {
+		t.Fatalf("hasMore = %#v, want true", output["hasMore"])
+	}
+}
+
+func TestHandleListVulnerabilities_PassesAfterAndReturnsEndCursor(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleListVulnerabilities(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"version_id": "version-1",
+				"limit":      2,
+				"after":      "vuln-cursor-1",
+				"severity":   "high",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListVulnerabilities returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListVulnerabilities returned tool error: %#v", result.Content)
+	}
+
+	if client.listVersionVulnsInput.VersionID != "version-1" {
+		t.Fatalf("VersionID = %#v, want version-1", client.listVersionVulnsInput.VersionID)
+	}
+	if client.listVersionVulnsInput.After != "vuln-cursor-1" {
+		t.Fatalf("After = %#v, want vuln-cursor-1", client.listVersionVulnsInput.After)
+	}
+	if client.listVersionVulnsInput.First != 2 {
+		t.Fatalf("First = %#v, want 2", client.listVersionVulnsInput.First)
+	}
+	if !reflect.DeepEqual(client.listVersionVulnsInput.Severity, []string{"high"}) {
+		t.Fatalf("Severity = %#v, want high", client.listVersionVulnsInput.Severity)
+	}
+
+	output := toolResultMap(t, result)
+	if output["endCursor"] != "vuln-cursor-2" {
+		t.Fatalf("endCursor = %#v, want vuln-cursor-2", output["endCursor"])
 	}
 	if output["hasMore"] != true {
 		t.Fatalf("hasMore = %#v, want true", output["hasMore"])

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -15,11 +15,75 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/interlynk-io/lynk-mcp/internal/api"
+	mcpg "github.com/mark3labs/mcp-go/mcp"
 )
+
+type fakeLynkClient struct {
+	lynkClient
+	listProductsInput api.ListProductsInput
+}
+
+func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error) {
+	f.listProductsInput = input
+	return &api.ProductsResult{
+		Products: []api.Product{
+			{
+				ID:            "product-1",
+				Name:          "Product 1",
+				Description:   "First product",
+				Enabled:       true,
+				VersionsCount: 7,
+			},
+		},
+		TotalCount:  3,
+		HasNextPage: true,
+		EndCursor:   "cursor-2",
+	}, nil
+}
+
+func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleListProducts(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"limit":  2,
+				"after":  "cursor-1",
+				"search": "Product",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListProducts returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListProducts returned tool error: %#v", result.Content)
+	}
+
+	if client.listProductsInput.After != "cursor-1" {
+		t.Fatalf("After = %#v, want cursor-1", client.listProductsInput.After)
+	}
+	if client.listProductsInput.Search != "Product" {
+		t.Fatalf("Search = %#v, want Product", client.listProductsInput.Search)
+	}
+	if client.listProductsInput.First != 2 {
+		t.Fatalf("First = %#v, want 2", client.listProductsInput.First)
+	}
+
+	output := toolResultMap(t, result)
+	if output["endCursor"] != "cursor-2" {
+		t.Fatalf("endCursor = %#v, want cursor-2", output["endCursor"])
+	}
+	if output["hasMore"] != true {
+		t.Fatalf("hasMore = %#v, want true", output["hasMore"])
+	}
+}
 
 func TestSameVexName_NormalizesCommonInputForms(t *testing.T) {
 	tests := []struct {
@@ -36,6 +100,22 @@ func TestSameVexName_NormalizesCommonInputForms(t *testing.T) {
 			t.Fatalf("sameVexName(%q, %q) = false, want true", tt.left, tt.right)
 		}
 	}
+}
+
+func toolResultMap(t *testing.T, result *mcpg.CallToolResult) map[string]interface{} {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one content item, got %d", len(result.Content))
+	}
+	text, ok := result.Content[0].(mcpg.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want TextContent", result.Content[0])
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(text.Text), &output); err != nil {
+		t.Fatalf("failed to decode tool result: %v", err)
+	}
+	return output
 }
 
 func TestGetVulnerabilityMetadataFilters_ExceptionalShortcut(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `after` input and `endCursor` output to `list_products`
- add `after` input and `endCursor` output to `list_vulnerabilities`
- add handler coverage for both cursor paths
- document cursor pagination in the README

## Validation
- `GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./internal/mcp`
- `GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./...`
- `make build`