### PR TITLE
Add lightweight product ticketing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Add to `~/.config/zed/settings.json`:
 
 `list_products` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.
 
+Product responses include lightweight repository import metadata when available. `list_products` also includes a compact Jira defaults summary; `get_product`, `list_environments`, and `get_environment` include per-environment `jiraDefaults` without invoking the heavier ticketing status scan.
+
 ### Versions, SBOM Doctor & Components
 
 | Tool | Description |

--- a/docs/customer-mcp-gaps.md
+++ b/docs/customer-mcp-gaps.md
@@ -229,11 +229,11 @@ Expected impact: fixes the unreachable products problem and separates config dis
 
 ### Phase 3: Lightweight ticketing fields on product tools
 
-- [ ] Extend product GraphQL queries to include `importedRepository.importStatus` where schema permits it.
-- [ ] Add a compact JIRA config projection to `get_product` and `get_environment` if `externalIssueTrackerSettings` is available on those API types.
-- [ ] If UI review finds a product-level abstraction over environment settings, add explicit fields with names that match the API model rather than overloading `issueTrackerSettings`.
-- [ ] Keep `list_products` response compact; include only repo import status and default ticketing summary, not full environment settings for every product.
-- [ ] Add tests for GitHub, GitLab, Bitbucket, and nil repository cases.
+- [x] Extend product GraphQL queries to include `importedRepository.importStatus` where schema permits it.
+- [x] Add a compact JIRA config projection to `get_product` and `get_environment` if `externalIssueTrackerSettings` is available on those API types.
+- [x] If UI review finds a product-level abstraction over environment settings, add explicit fields with names that match the API model rather than overloading `issueTrackerSettings`.
+- [x] Keep `list_products` response compact; include only repo import status and default ticketing summary, not full environment settings for every product.
+- [x] Add tests for GitHub, GitLab, Bitbucket, and nil repository cases.
 
 Expected impact: customers can inspect repo import status and JIRA defaults without invoking heavy ticketing status scans.
 

--- a/internal/api/products.go
+++ b/internal/api/products.go
@@ -27,14 +27,16 @@ const getProductEnvironmentsPageSize = 100
 
 // Product represents a product (formerly project group)
 type Product struct {
-	ID             string
-	Name           string
-	Description    string
-	Enabled        bool
-	OrganizationID string
-	UpdatedAt      time.Time
-	VersionsCount  int
-	Environments   []Environment
+	ID                       string
+	Name                     string
+	Description              string
+	Enabled                  bool
+	OrganizationID           string
+	UpdatedAt                time.Time
+	VersionsCount            int
+	Repository               *ImportedRepository
+	TicketingDefaultsSummary *TicketingDefaultsSummary
+	Environments             []Environment
 }
 
 // Environment represents an environment (formerly project)
@@ -46,7 +48,28 @@ type Environment struct {
 	ProductID     string
 	UpdatedAt     time.Time
 	VersionsCount int
+	JiraDefaults  *JiraDefaults
 	Product       *Product
+}
+
+// TicketingDefaultsSummary contains compact per-product ticketing defaults.
+type TicketingDefaultsSummary struct {
+	JiraConfigured       bool
+	JiraProjectKeys      []string
+	EnvironmentsWithJira int
+}
+
+// JiraDefaults contains compact per-environment Jira defaults used for ticket creation.
+type JiraDefaults struct {
+	ID         string
+	ProjectKey string
+	IssueType  string
+	Assignee   string
+	Reporter   string
+	Epic       string
+	Components interface{}
+	EnableSync bool
+	UpdatedAt  time.Time
 }
 
 // ProductsResult represents the result of listing products
@@ -83,13 +106,19 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 		Organization struct {
 			ProjectGroups struct {
 				Nodes []struct {
-					ID             string    `json:"id"`
-					Name           string    `json:"name"`
-					Description    string    `json:"description"`
-					Enabled        bool      `json:"enabled"`
-					OrganizationID string    `json:"organizationId"`
-					UpdatedAt      time.Time `json:"updatedAt"`
-					SbomsCount     int       `json:"sbomsCount"`
+					ID                 string                 `json:"id"`
+					Name               string                 `json:"name"`
+					Description        string                 `json:"description"`
+					Enabled            bool                   `json:"enabled"`
+					OrganizationID     string                 `json:"organizationId"`
+					UpdatedAt          time.Time              `json:"updatedAt"`
+					SbomsCount         int                    `json:"sbomsCount"`
+					ImportedRepository *productRepositoryNode `json:"importedRepository"`
+					Projects           struct {
+						Nodes []struct {
+							ExternalIssueTrackerSettings []productIssueTrackerSettingNode `json:"externalIssueTrackerSettings"`
+						} `json:"nodes"`
+					} `json:"projects"`
 				} `json:"nodes"`
 				TotalCount int `json:"totalCount"`
 				PageInfo   struct {
@@ -107,13 +136,15 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 	products := make([]Product, len(result.Organization.ProjectGroups.Nodes))
 	for i, n := range result.Organization.ProjectGroups.Nodes {
 		products[i] = Product{
-			ID:             n.ID,
-			Name:           n.Name,
-			Description:    n.Description,
-			Enabled:        n.Enabled,
-			OrganizationID: n.OrganizationID,
-			UpdatedAt:      n.UpdatedAt,
-			VersionsCount:  n.SbomsCount,
+			ID:                       n.ID,
+			Name:                     n.Name,
+			Description:              n.Description,
+			Enabled:                  n.Enabled,
+			OrganizationID:           n.OrganizationID,
+			UpdatedAt:                n.UpdatedAt,
+			VersionsCount:            n.SbomsCount,
+			Repository:               mapProductRepository(n.ImportedRepository),
+			TicketingDefaultsSummary: summarizeTicketingDefaults(n.Projects.Nodes),
 		}
 	}
 
@@ -142,21 +173,23 @@ func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
 
 		var result struct {
 			ProjectGroup struct {
-				ID             string    `json:"id"`
-				Name           string    `json:"name"`
-				Description    string    `json:"description"`
-				Enabled        bool      `json:"enabled"`
-				OrganizationID string    `json:"organizationId"`
-				UpdatedAt      time.Time `json:"updatedAt"`
-				SbomsCount     int       `json:"sbomsCount"`
-				Projects       struct {
+				ID                 string                 `json:"id"`
+				Name               string                 `json:"name"`
+				Description        string                 `json:"description"`
+				Enabled            bool                   `json:"enabled"`
+				OrganizationID     string                 `json:"organizationId"`
+				UpdatedAt          time.Time              `json:"updatedAt"`
+				SbomsCount         int                    `json:"sbomsCount"`
+				ImportedRepository *productRepositoryNode `json:"importedRepository"`
+				Projects           struct {
 					Nodes []struct {
-						ID          string    `json:"id"`
-						Name        string    `json:"name"`
-						Description string    `json:"description"`
-						Enabled     bool      `json:"enabled"`
-						UpdatedAt   time.Time `json:"updatedAt"`
-						SbomsCount  int       `json:"sbomsCount"`
+						ID                           string                           `json:"id"`
+						Name                         string                           `json:"name"`
+						Description                  string                           `json:"description"`
+						Enabled                      bool                             `json:"enabled"`
+						UpdatedAt                    time.Time                        `json:"updatedAt"`
+						SbomsCount                   int                              `json:"sbomsCount"`
+						ExternalIssueTrackerSettings []productIssueTrackerSettingNode `json:"externalIssueTrackerSettings"`
 					} `json:"nodes"`
 					PageInfo struct {
 						HasNextPage bool   `json:"hasNextPage"`
@@ -179,6 +212,7 @@ func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
 				OrganizationID: result.ProjectGroup.OrganizationID,
 				UpdatedAt:      result.ProjectGroup.UpdatedAt,
 				VersionsCount:  result.ProjectGroup.SbomsCount,
+				Repository:     mapProductRepository(result.ProjectGroup.ImportedRepository),
 			}
 		}
 
@@ -191,6 +225,7 @@ func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
 				UpdatedAt:     p.UpdatedAt,
 				VersionsCount: p.SbomsCount,
 				ProductID:     result.ProjectGroup.ID,
+				JiraDefaults:  mapJiraDefaults(p.ExternalIssueTrackerSettings),
 			})
 		}
 
@@ -223,16 +258,18 @@ func (c *Client) GetEnvironment(ctx context.Context, id string) (*Environment, e
 
 	var result struct {
 		Project struct {
-			ID             string    `json:"id"`
-			Name           string    `json:"name"`
-			Description    string    `json:"description"`
-			Enabled        bool      `json:"enabled"`
-			ProjectGroupID string    `json:"projectGroupId"`
-			UpdatedAt      time.Time `json:"updatedAt"`
-			SbomsCount     int       `json:"sbomsCount"`
-			ProjectGroup   struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
+			ID                           string                           `json:"id"`
+			Name                         string                           `json:"name"`
+			Description                  string                           `json:"description"`
+			Enabled                      bool                             `json:"enabled"`
+			ProjectGroupID               string                           `json:"projectGroupId"`
+			UpdatedAt                    time.Time                        `json:"updatedAt"`
+			SbomsCount                   int                              `json:"sbomsCount"`
+			ExternalIssueTrackerSettings []productIssueTrackerSettingNode `json:"externalIssueTrackerSettings"`
+			ProjectGroup                 struct {
+				ID                 string                 `json:"id"`
+				Name               string                 `json:"name"`
+				ImportedRepository *productRepositoryNode `json:"importedRepository"`
 			} `json:"projectGroup"`
 		} `json:"project"`
 	}
@@ -244,8 +281,9 @@ func (c *Client) GetEnvironment(ctx context.Context, id string) (*Environment, e
 	var product *Product
 	if result.Project.ProjectGroup.ID != "" {
 		product = &Product{
-			ID:   result.Project.ProjectGroup.ID,
-			Name: result.Project.ProjectGroup.Name,
+			ID:         result.Project.ProjectGroup.ID,
+			Name:       result.Project.ProjectGroup.Name,
+			Repository: mapProductRepository(result.Project.ProjectGroup.ImportedRepository),
 		}
 	}
 
@@ -257,6 +295,108 @@ func (c *Client) GetEnvironment(ctx context.Context, id string) (*Environment, e
 		ProductID:     result.Project.ProjectGroupID,
 		UpdatedAt:     result.Project.UpdatedAt,
 		VersionsCount: result.Project.SbomsCount,
+		JiraDefaults:  mapJiraDefaults(result.Project.ExternalIssueTrackerSettings),
 		Product:       product,
 	}, nil
+}
+
+type productRepositoryNode struct {
+	Type           string `json:"__typename"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	FullName       string `json:"fullName"`
+	Owner          string `json:"owner"`
+	DefaultBranch  string `json:"defaultBranch"`
+	Slug           string `json:"slug"`
+	Workspace      string `json:"workspace"`
+	FullPath       string `json:"fullPath"`
+	GitlabID       string `json:"gitlabId"`
+	ImportStatus   string `json:"importStatus"`
+	WebhookEnabled bool   `json:"webhookEnabled"`
+}
+
+type productIssueTrackerSettingNode struct {
+	ID             string      `json:"id"`
+	Provider       string      `json:"provider"`
+	ProjectKey     string      `json:"projectKey"`
+	IssueType      string      `json:"issueType"`
+	Assignee       string      `json:"assignee"`
+	Reporter       string      `json:"reporter"`
+	Epic           string      `json:"epic"`
+	Components     interface{} `json:"components"`
+	EnableJiraSync bool        `json:"enableJiraSync"`
+	UpdatedAt      time.Time   `json:"updatedAt"`
+}
+
+func mapProductRepository(node *productRepositoryNode) *ImportedRepository {
+	if node == nil {
+		return nil
+	}
+	return &ImportedRepository{
+		Type:           node.Type,
+		ID:             node.ID,
+		Name:           node.Name,
+		FullName:       node.FullName,
+		Owner:          node.Owner,
+		DefaultBranch:  node.DefaultBranch,
+		Slug:           node.Slug,
+		Workspace:      node.Workspace,
+		FullPath:       node.FullPath,
+		GitlabID:       node.GitlabID,
+		ImportStatus:   node.ImportStatus,
+		WebhookEnabled: node.WebhookEnabled,
+	}
+}
+
+func mapJiraDefaults(settings []productIssueTrackerSettingNode) *JiraDefaults {
+	for _, setting := range settings {
+		if setting.Provider != "jira" {
+			continue
+		}
+		return &JiraDefaults{
+			ID:         setting.ID,
+			ProjectKey: setting.ProjectKey,
+			IssueType:  setting.IssueType,
+			Assignee:   setting.Assignee,
+			Reporter:   setting.Reporter,
+			Epic:       setting.Epic,
+			Components: setting.Components,
+			EnableSync: setting.EnableJiraSync,
+			UpdatedAt:  setting.UpdatedAt,
+		}
+	}
+	return nil
+}
+
+func summarizeTicketingDefaults(environments []struct {
+	ExternalIssueTrackerSettings []productIssueTrackerSettingNode `json:"externalIssueTrackerSettings"`
+}) *TicketingDefaultsSummary {
+	keys := map[string]bool{}
+	environmentsWithJira := 0
+	for _, env := range environments {
+		hasJira := false
+		for _, setting := range env.ExternalIssueTrackerSettings {
+			if setting.Provider != "jira" {
+				continue
+			}
+			hasJira = true
+			if setting.ProjectKey != "" {
+				keys[setting.ProjectKey] = true
+			}
+		}
+		if hasJira {
+			environmentsWithJira++
+		}
+	}
+
+	summary := &TicketingDefaultsSummary{
+		JiraConfigured:       environmentsWithJira > 0,
+		JiraProjectKeys:      []string{},
+		EnvironmentsWithJira: environmentsWithJira,
+	}
+	for key := range keys {
+		summary.JiraProjectKeys = append(summary.JiraProjectKeys, key)
+	}
+	sort.Strings(summary.JiraProjectKeys)
+	return summary
 }

--- a/internal/api/products_test.go
+++ b/internal/api/products_test.go
@@ -32,6 +32,141 @@ func (f *fakeGraphQLExecutor) Execute(ctx context.Context, query string, variabl
 	return json.Unmarshal([]byte(f.pages[len(f.requests)-1]), result)
 }
 
+func TestListProducts_MapsImportedRepositoryTypesAndTicketingSummary(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"organization": {
+					"projectGroups": {
+						"nodes": [
+							{
+								"id": "github-product",
+								"name": "GitHub Product",
+								"description": "",
+								"enabled": true,
+								"organizationId": "org-1",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 1,
+								"importedRepository": {
+									"__typename": "GithubRepository",
+									"id": "repo-github",
+									"name": "repo",
+									"fullName": "org/repo",
+									"owner": "org",
+									"defaultBranch": "main",
+									"importStatus": "completed",
+									"webhookEnabled": true
+								},
+								"projects": {
+									"nodes": [
+										{
+											"externalIssueTrackerSettings": [
+												{"provider": "jira", "projectKey": "SEC"}
+											]
+										},
+										{
+											"externalIssueTrackerSettings": [
+												{"provider": "jira", "projectKey": "OPS"}
+											]
+										}
+									]
+								}
+							},
+							{
+								"id": "bitbucket-product",
+								"name": "Bitbucket Product",
+								"description": "",
+								"enabled": true,
+								"organizationId": "org-1",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 2,
+								"importedRepository": {
+									"__typename": "BitbucketRepository",
+									"id": "repo-bitbucket",
+									"name": "repo",
+									"fullName": "workspace/repo",
+									"slug": "repo",
+									"workspace": "workspace",
+									"importStatus": "in_progress",
+									"webhookEnabled": false
+								},
+								"projects": {"nodes": []}
+							},
+							{
+								"id": "gitlab-product",
+								"name": "GitLab Product",
+								"description": "",
+								"enabled": true,
+								"organizationId": "org-1",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 3,
+								"importedRepository": {
+									"__typename": "GitlabRepository",
+									"id": "repo-gitlab",
+									"name": "repo",
+									"fullPath": "group/repo",
+									"gitlabId": "123",
+									"importStatus": "failed",
+									"webhookEnabled": true
+								},
+								"projects": {"nodes": []}
+							},
+							{
+								"id": "nil-product",
+								"name": "Nil Product",
+								"description": "",
+								"enabled": true,
+								"organizationId": "org-1",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 4,
+								"importedRepository": null,
+								"projects": {"nodes": []}
+							}
+						],
+						"totalCount": 4,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListProducts(context.Background(), ListProductsInput{First: 4})
+	if err != nil {
+		t.Fatalf("ListProducts returned error: %v", err)
+	}
+	products := result.Products
+	if products[0].Repository.Type != "GithubRepository" || products[0].Repository.ImportStatus != "completed" || products[0].Repository.FullName != "org/repo" {
+		t.Fatalf("unexpected GitHub repository: %#v", products[0].Repository)
+	}
+	if products[1].Repository.Type != "BitbucketRepository" || products[1].Repository.ImportStatus != "in_progress" || products[1].Repository.Workspace != "workspace" {
+		t.Fatalf("unexpected Bitbucket repository: %#v", products[1].Repository)
+	}
+	if products[2].Repository.Type != "GitlabRepository" || products[2].Repository.ImportStatus != "failed" || products[2].Repository.FullPath != "group/repo" {
+		t.Fatalf("unexpected GitLab repository: %#v", products[2].Repository)
+	}
+	if products[3].Repository != nil {
+		t.Fatalf("nil repository product Repository = %#v, want nil", products[3].Repository)
+	}
+	summary := products[0].TicketingDefaultsSummary
+	if summary == nil || !summary.JiraConfigured || summary.EnvironmentsWithJira != 2 {
+		t.Fatalf("unexpected ticketing summary: %#v", summary)
+	}
+	wantKeys := []string{"OPS", "SEC"}
+	if len(summary.JiraProjectKeys) != len(wantKeys) {
+		t.Fatalf("JiraProjectKeys = %#v, want %#v", summary.JiraProjectKeys, wantKeys)
+	}
+	for i := range wantKeys {
+		if summary.JiraProjectKeys[i] != wantKeys[i] {
+			t.Fatalf("JiraProjectKeys = %#v, want %#v", summary.JiraProjectKeys, wantKeys)
+		}
+	}
+}
+
 func TestGetProduct_PaginatesEnvironments(t *testing.T) {
 	gql := &fakeGraphQLExecutor{
 		pages: []string{
@@ -180,5 +315,149 @@ func TestGetProduct_OrdersEnvironmentsWithVersionsFirst(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("environment order = %#v, want %#v", got, want)
 		}
+	}
+}
+
+func TestGetProduct_MapsRepositoryAndJiraDefaults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"projectGroup": {
+					"id": "product-1",
+					"name": "Product 1",
+					"description": "",
+					"enabled": true,
+					"organizationId": "org-1",
+					"updatedAt": "2026-04-16T23:00:09Z",
+					"sbomsCount": 1,
+					"importedRepository": {
+						"__typename": "GithubRepository",
+						"id": "repo-1",
+						"name": "repo",
+						"fullName": "org/repo",
+						"owner": "org",
+						"defaultBranch": "main",
+						"importStatus": "completed",
+						"webhookEnabled": true
+					},
+					"projects": {
+						"nodes": [
+							{
+								"id": "env-1",
+								"name": "default",
+								"description": "",
+								"enabled": true,
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 1,
+								"externalIssueTrackerSettings": [
+									{
+										"id": "linear-setting",
+										"provider": "linear",
+										"projectKey": "",
+										"issueType": "",
+										"assignee": "",
+										"reporter": "",
+										"epic": "",
+										"components": null,
+										"enableJiraSync": false,
+										"updatedAt": "2026-04-16T23:00:09Z"
+									},
+									{
+										"id": "jira-setting",
+										"provider": "jira",
+										"projectKey": "SEC",
+										"issueType": "10001",
+										"assignee": "alice",
+										"reporter": "bot",
+										"epic": "SEC-1",
+										"components": ["backend"],
+										"enableJiraSync": true,
+										"updatedAt": "2026-04-16T23:00:09Z"
+									}
+								]
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	product, err := client.GetProduct(context.Background(), "product-1")
+	if err != nil {
+		t.Fatalf("GetProduct returned error: %v", err)
+	}
+	if product.Repository == nil || product.Repository.ImportStatus != "completed" {
+		t.Fatalf("unexpected repository: %#v", product.Repository)
+	}
+	defaults := product.Environments[0].JiraDefaults
+	if defaults == nil {
+		t.Fatal("JiraDefaults = nil, want defaults")
+	}
+	if defaults.ProjectKey != "SEC" || defaults.IssueType != "10001" || !defaults.EnableSync {
+		t.Fatalf("unexpected Jira defaults: %#v", defaults)
+	}
+}
+
+func TestGetEnvironment_MapsJiraDefaultsAndProductRepository(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"project": {
+					"id": "env-1",
+					"name": "default",
+					"description": "",
+					"enabled": true,
+					"projectGroupId": "product-1",
+					"updatedAt": "2026-04-16T23:00:09Z",
+					"sbomsCount": 1,
+					"externalIssueTrackerSettings": [
+						{
+							"id": "jira-setting",
+							"provider": "jira",
+							"projectKey": "SEC",
+							"issueType": "10001",
+							"assignee": "alice",
+							"reporter": "bot",
+							"epic": "SEC-1",
+							"components": ["backend"],
+							"enableJiraSync": true,
+							"updatedAt": "2026-04-16T23:00:09Z"
+						}
+					],
+					"projectGroup": {
+						"id": "product-1",
+						"name": "Product 1",
+						"importedRepository": {
+							"__typename": "BitbucketRepository",
+							"id": "repo-1",
+							"name": "repo",
+							"fullName": "workspace/repo",
+							"slug": "repo",
+							"workspace": "workspace",
+							"importStatus": "completed",
+							"webhookEnabled": true
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	env, err := client.GetEnvironment(context.Background(), "env-1")
+	if err != nil {
+		t.Fatalf("GetEnvironment returned error: %v", err)
+	}
+	if env.JiraDefaults == nil || env.JiraDefaults.ProjectKey != "SEC" {
+		t.Fatalf("unexpected Jira defaults: %#v", env.JiraDefaults)
+	}
+	if env.Product == nil || env.Product.Repository == nil || env.Product.Repository.Type != "BitbucketRepository" {
+		t.Fatalf("unexpected product repository: %#v", env.Product)
 	}
 }

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -61,6 +61,43 @@ const (
 						organizationId
 						updatedAt
 						sbomsCount
+						importedRepository {
+							__typename
+							... on GithubRepository {
+								id
+								name
+								fullName
+								owner
+								defaultBranch
+								importStatus
+								webhookEnabled
+							}
+							... on BitbucketRepository {
+								id
+								name
+								fullName
+								slug
+								workspace
+								importStatus
+								webhookEnabled
+							}
+							... on GitlabRepository {
+								id
+								name
+								fullPath
+								gitlabId
+								importStatus
+								webhookEnabled
+							}
+						}
+						projects(first: 100) {
+							nodes {
+								externalIssueTrackerSettings {
+									provider
+									projectKey
+								}
+							}
+						}
 					}
 					totalCount
 					pageInfo {
@@ -85,6 +122,35 @@ const (
 				organizationId
 				updatedAt
 				sbomsCount
+				importedRepository {
+					__typename
+					... on GithubRepository {
+						id
+						name
+						fullName
+						owner
+						defaultBranch
+						importStatus
+						webhookEnabled
+					}
+					... on BitbucketRepository {
+						id
+						name
+						fullName
+						slug
+						workspace
+						importStatus
+						webhookEnabled
+					}
+					... on GitlabRepository {
+						id
+						name
+						fullPath
+						gitlabId
+						importStatus
+						webhookEnabled
+					}
+				}
 				projects(first: $projectsFirst, after: $projectsAfter) {
 					nodes {
 						id
@@ -93,6 +159,18 @@ const (
 						enabled
 						updatedAt
 						sbomsCount
+						externalIssueTrackerSettings {
+							id
+							provider
+							projectKey
+							issueType
+							assignee
+							reporter
+							epic
+							components
+							enableJiraSync
+							updatedAt
+						}
 					}
 					pageInfo {
 						hasNextPage
@@ -114,9 +192,50 @@ const (
 				projectGroupId
 				updatedAt
 				sbomsCount
+				externalIssueTrackerSettings {
+					id
+					provider
+					projectKey
+					issueType
+					assignee
+					reporter
+					epic
+					components
+					enableJiraSync
+					updatedAt
+				}
 				projectGroup {
 					id
 					name
+					importedRepository {
+						__typename
+						... on GithubRepository {
+							id
+							name
+							fullName
+							owner
+							defaultBranch
+							importStatus
+							webhookEnabled
+						}
+						... on BitbucketRepository {
+							id
+							name
+							fullName
+							slug
+							workspace
+							importStatus
+							webhookEnabled
+						}
+						... on GitlabRepository {
+							id
+							name
+							fullPath
+							gitlabId
+							importStatus
+							webhookEnabled
+						}
+					}
 				}
 			}
 		}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -81,6 +81,12 @@ func (s *Server) handleListProducts(ctx context.Context, request mcp.CallToolReq
 			"versionsCount": p.VersionsCount,
 			"updatedAt":     p.UpdatedAt,
 		}
+		if p.Repository != nil {
+			products[i]["repository"] = formatImportedRepository(p.Repository)
+		}
+		if p.TicketingDefaultsSummary != nil {
+			products[i]["ticketingDefaultsSummary"] = formatTicketingDefaultsSummary(p.TicketingDefaultsSummary)
+		}
 	}
 
 	return formatResult(map[string]interface{}{
@@ -113,9 +119,12 @@ func (s *Server) handleGetProduct(ctx context.Context, request mcp.CallToolReque
 			"versionsCount": e.VersionsCount,
 			"updatedAt":     e.UpdatedAt,
 		}
+		if e.JiraDefaults != nil {
+			environments[i]["jiraDefaults"] = formatJiraDefaults(e.JiraDefaults)
+		}
 	}
 
-	return formatResult(map[string]interface{}{
+	result := map[string]interface{}{
 		"id":            product.ID,
 		"name":          product.Name,
 		"description":   product.Description,
@@ -123,7 +132,12 @@ func (s *Server) handleGetProduct(ctx context.Context, request mcp.CallToolReque
 		"versionsCount": product.VersionsCount,
 		"updatedAt":     product.UpdatedAt,
 		"environments":  environments,
-	})
+	}
+	if product.Repository != nil {
+		result["repository"] = formatImportedRepository(product.Repository)
+	}
+
+	return formatResult(result)
 }
 
 func (s *Server) handleListEnvironments(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -153,6 +167,9 @@ func (s *Server) handleListEnvironments(ctx context.Context, request mcp.CallToo
 			"versionsCount": e.VersionsCount,
 			"updatedAt":     e.UpdatedAt,
 		})
+		if e.JiraDefaults != nil {
+			environments[len(environments)-1]["jiraDefaults"] = formatJiraDefaults(e.JiraDefaults)
+		}
 	}
 
 	return formatResult(map[string]interface{}{
@@ -182,12 +199,19 @@ func (s *Server) handleGetEnvironment(ctx context.Context, request mcp.CallToolR
 		"versionsCount": environment.VersionsCount,
 		"updatedAt":     environment.UpdatedAt,
 	}
+	if environment.JiraDefaults != nil {
+		result["jiraDefaults"] = formatJiraDefaults(environment.JiraDefaults)
+	}
 
 	if environment.Product != nil {
-		result["product"] = map[string]interface{}{
+		product := map[string]interface{}{
 			"id":   environment.Product.ID,
 			"name": environment.Product.Name,
 		}
+		if environment.Product.Repository != nil {
+			product["repository"] = formatImportedRepository(environment.Product.Repository)
+		}
+		result["product"] = product
 	}
 
 	return formatResult(result)
@@ -1859,6 +1883,31 @@ func formatTicketingStatus(status *api.TicketingStatus) map[string]interface{} {
 	result["policies"] = policies
 	result["createdTickets"] = formatCreatedTickets(status.CreatedTickets)
 
+	return result
+}
+
+func formatTicketingDefaultsSummary(summary *api.TicketingDefaultsSummary) map[string]interface{} {
+	return map[string]interface{}{
+		"jiraConfigured":       summary.JiraConfigured,
+		"jiraProjectKeys":      summary.JiraProjectKeys,
+		"environmentsWithJira": summary.EnvironmentsWithJira,
+	}
+}
+
+func formatJiraDefaults(defaults *api.JiraDefaults) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":         defaults.ID,
+		"projectKey": defaults.ProjectKey,
+		"issueType":  defaults.IssueType,
+		"assignee":   defaults.Assignee,
+		"reporter":   defaults.Reporter,
+		"epic":       defaults.Epic,
+		"enableSync": defaults.EnableSync,
+		"updatedAt":  defaults.UpdatedAt,
+	}
+	if defaults.Components != nil {
+		result["components"] = defaults.Components
+	}
 	return result
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -41,11 +41,83 @@ func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProduct
 				Description:   "First product",
 				Enabled:       true,
 				VersionsCount: 7,
+				Repository: &api.ImportedRepository{
+					Type:           "GithubRepository",
+					ID:             "repo-1",
+					Name:           "repo",
+					FullName:       "org/repo",
+					ImportStatus:   "completed",
+					WebhookEnabled: true,
+				},
+				TicketingDefaultsSummary: &api.TicketingDefaultsSummary{
+					JiraConfigured:       true,
+					JiraProjectKeys:      []string{"SEC"},
+					EnvironmentsWithJira: 1,
+				},
 			},
 		},
 		TotalCount:  3,
 		HasNextPage: true,
 		EndCursor:   "cursor-2",
+	}, nil
+}
+
+func (f *fakeLynkClient) GetProduct(ctx context.Context, id string) (*api.Product, error) {
+	return &api.Product{
+		ID:            id,
+		Name:          "Product 1",
+		Description:   "First product",
+		Enabled:       true,
+		VersionsCount: 7,
+		Repository: &api.ImportedRepository{
+			Type:           "BitbucketRepository",
+			ID:             "repo-1",
+			Name:           "repo",
+			FullName:       "workspace/repo",
+			ImportStatus:   "completed",
+			WebhookEnabled: true,
+		},
+		Environments: []api.Environment{
+			{
+				ID:            "env-1",
+				Name:          "default",
+				Enabled:       true,
+				VersionsCount: 1,
+				JiraDefaults: &api.JiraDefaults{
+					ID:         "jira-setting",
+					ProjectKey: "SEC",
+					IssueType:  "10001",
+					EnableSync: true,
+				},
+			},
+		},
+	}, nil
+}
+
+func (f *fakeLynkClient) GetEnvironment(ctx context.Context, id string) (*api.Environment, error) {
+	return &api.Environment{
+		ID:            id,
+		Name:          "default",
+		Enabled:       true,
+		ProductID:     "product-1",
+		VersionsCount: 1,
+		JiraDefaults: &api.JiraDefaults{
+			ID:         "jira-setting",
+			ProjectKey: "SEC",
+			IssueType:  "10001",
+			EnableSync: true,
+		},
+		Product: &api.Product{
+			ID:   "product-1",
+			Name: "Product 1",
+			Repository: &api.ImportedRepository{
+				Type:         "BitbucketRepository",
+				ID:           "repo-1",
+				Name:         "repo",
+				FullName:     "workspace/repo",
+				ImportStatus: "completed",
+			},
+		},
 	}, nil
 }
 
@@ -124,6 +196,61 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 	}
 	if output["hasMore"] != true {
 		t.Fatalf("hasMore = %#v, want true", output["hasMore"])
+	}
+	products := output["products"].([]interface{})
+	product := products[0].(map[string]interface{})
+	repository := product["repository"].(map[string]interface{})
+	if repository["importStatus"] != "completed" || repository["fullName"] != "org/repo" {
+		t.Fatalf("unexpected repository output: %#v", repository)
+	}
+	summary := product["ticketingDefaultsSummary"].(map[string]interface{})
+	if summary["jiraConfigured"] != true {
+		t.Fatalf("unexpected ticketing summary output: %#v", summary)
+	}
+}
+
+func TestHandleGetProduct_ReturnsRepositoryAndJiraDefaults(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleGetProduct(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{"id": "product-1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleGetProduct returned error: %v", err)
+	}
+	output := toolResultMap(t, result)
+	repository := output["repository"].(map[string]interface{})
+	if repository["type"] != "BitbucketRepository" || repository["importStatus"] != "completed" {
+		t.Fatalf("unexpected repository output: %#v", repository)
+	}
+	environments := output["environments"].([]interface{})
+	env := environments[0].(map[string]interface{})
+	defaults := env["jiraDefaults"].(map[string]interface{})
+	if defaults["projectKey"] != "SEC" || defaults["enableSync"] != true {
+		t.Fatalf("unexpected Jira defaults output: %#v", defaults)
+	}
+}
+
+func TestHandleGetEnvironment_ReturnsJiraDefaultsAndProductRepository(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleGetEnvironment(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{"id": "env-1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleGetEnvironment returned error: %v", err)
+	}
+	output := toolResultMap(t, result)
+	defaults := output["jiraDefaults"].(map[string]interface{})
+	if defaults["projectKey"] != "SEC" || defaults["enableSync"] != true {
+		t.Fatalf("unexpected Jira defaults output: %#v", defaults)
+	}
+	product := output["product"].(map[string]interface{})
+	repository := product["repository"].(map[string]interface{})
+	if repository["type"] != "BitbucketRepository" || repository["importStatus"] != "completed" {
+		t.Fatalf("unexpected product repository output: %#v", repository)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose lightweight repository import metadata on product responses
- add compact Jira defaults to product/environment tools without using the heavy ticketing status scan
- add API and MCP tests for GitHub, GitLab, Bitbucket, nil repository, and Jira defaults mapping
- mark Phase 3 complete in the customer MCP gaps plan

## Validation
- `GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./...`
- `make build`