### PR TITLE
Add component-scoped vulnerability filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ Product responses include lightweight repository import metadata when available.
 
 `list_vulnerabilities` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.
 
+`list_vulnerabilities` can filter a version by `component_id` or exact component `purl`. `search_vulnerabilities` can filter across the organization by `component_id`, `component_ids`, or exact `purl`, and supports `after`/`endCursor` pagination.
+
 ### Supply-Chain Security Incidents
 
 | Tool | Description |

--- a/docs/customer-mcp-gaps.md
+++ b/docs/customer-mcp-gaps.md
@@ -240,20 +240,25 @@ Expected impact: customers can inspect repo import status and JIRA defaults with
 ### Phase 4: Component-scoped vulnerability triage
 
 - [x] Check `lynk-api` schema for existing component filters on `sbom.vulns` or `componentVulns`.
-- [ ] Add MCP support for API-supported component ID filtering, likely via `componentVulns(componentIds: ...)` or a version-scoped API addition.
+- [x] Add MCP support for API-supported component ID filtering, likely via `componentVulns(componentIds: ...)` or a version-scoped API addition.
 - [ ] Add API support for purl filtering if exact purl filtering is required server-side.
-- [ ] Treat purl filtering carefully:
+- [x] Treat purl filtering carefully:
   - Prefer exact purl match.
   - Define behavior for empty purl.
   - Decide whether purl is scoped by version ID, org, or component ID.
-- [ ] Return stable component identifiers in the vulnerability response:
+- [x] Return stable component identifiers in the vulnerability response:
   - `component.id`
   - `component.name`
   - `component.version`
   - `component.purl`
   - `component.bomRef` if available
   - `component.sbomId` or `versionId`
-- [ ] Add tests for component ID, purl, empty purl, and pagination combined with component filters.
+- [x] Add tests for component ID, purl, empty purl, and pagination combined with component filters.
+
+Notes:
+- `componentVulns(componentIds: ...)` is used for org-wide `search_vulnerabilities`; version-scoped `list_vulnerabilities` filters component IDs within `sbom.vulns` results.
+- Exact `purl` filtering is implemented in MCP response handling. Server-side purl filtering remains open until the API exposes it.
+- `component.bomRef` was not added because it is not exposed by the current API schema; responses include component id, name, version, purl, and `sbomId`/`versionId` where available.
 
 Expected impact: customers can enumerate all findings for a component and perform class disposition with auditability.
 

--- a/internal/api/vulnerabilities.go
+++ b/internal/api/vulnerabilities.go
@@ -89,15 +89,17 @@ type ComponentVulnsResult struct {
 
 // ListVersionVulnsInput contains parameters for listing version vulnerabilities
 type ListVersionVulnsInput struct {
-	VersionID string
-	First     int
-	After     string
-	Severity  []string
-	Status    []string
-	Kev       *bool
-	EpssMin   *float64
-	EpssMax   *float64
-	Search    string
+	VersionID    string
+	First        int
+	After        string
+	Severity     []string
+	Status       []string
+	Kev          *bool
+	EpssMin      *float64
+	EpssMax      *float64
+	Search       string
+	ComponentIDs []string
+	Purl         string
 }
 
 // ListVersionVulns fetches vulnerabilities for a version
@@ -147,6 +149,7 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 						Name    string `json:"name"`
 						Version string `json:"version"`
 						Purl    string `json:"purl"`
+						SbomID  string `json:"sbomId"`
 					} `json:"component"`
 					Vuln *struct {
 						ID             string               `json:"id"`
@@ -205,10 +208,11 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 		}
 		if n.Component != nil {
 			cv.Component = &VersionComponent{
-				ID:      n.Component.ID,
-				Name:    n.Component.Name,
-				Version: n.Component.Version,
-				Purl:    n.Component.Purl,
+				ID:        n.Component.ID,
+				Name:      n.Component.Name,
+				Version:   n.Component.Version,
+				Purl:      n.Component.Purl,
+				VersionID: n.Component.SbomID,
 			}
 		}
 		if n.Vuln != nil {
@@ -386,6 +390,8 @@ type ListComponentVulnsInput struct {
 	EpssMin        *float64
 	EpssMax        *float64
 	Search         string
+	ComponentIDs   []string
+	Purl           string
 	EnvironmentIDs []string
 	ProductIDs     []string
 }
@@ -413,6 +419,9 @@ func (c *Client) ListComponentVulns(ctx context.Context, input ListComponentVuln
 	addEpssRangeVar(vars, input.EpssMin, input.EpssMax)
 	if input.Search != "" {
 		vars["search"] = input.Search
+	}
+	if len(input.ComponentIDs) > 0 {
+		vars["componentIds"] = input.ComponentIDs
 	}
 	if len(input.EnvironmentIDs) > 0 {
 		vars["projectIds"] = input.EnvironmentIDs

--- a/internal/api/vulnerabilities_test.go
+++ b/internal/api/vulnerabilities_test.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -119,6 +120,46 @@ func TestListVersionVulns_AcceptsNestedVulnTimestampsWithoutTimezone(t *testing.
 	wantPublished := time.Date(2025, 6, 30, 21, 15, 30, 257000000, time.UTC)
 	if !result.ComponentVulns[0].Vuln.PublishedAt.Equal(wantPublished) {
 		t.Fatalf("PublishedAt = %s, want %s", result.ComponentVulns[0].Vuln.PublishedAt, wantPublished)
+	}
+}
+
+func TestListComponentVulns_PassesComponentIDs(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentVulns": {
+					"nodes": [],
+					"totalCount": 0,
+					"pageInfo": {
+						"hasNextPage": false,
+						"endCursor": ""
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	_, err := client.ListComponentVulns(context.Background(), ListComponentVulnsInput{
+		ComponentIDs: []string{"component-1", "component-2"},
+		After:        "cursor-1",
+		First:        25,
+	})
+	if err != nil {
+		t.Fatalf("ListComponentVulns returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["after"] != "cursor-1" || request["first"] != 25 {
+		t.Fatalf("unexpected pagination variables: %#v", request)
+	}
+	got, ok := request["componentIds"].([]string)
+	if !ok {
+		t.Fatalf("componentIds = %T %#v, want []string", request["componentIds"], request["componentIds"])
+	}
+	want := []string{"component-1", "component-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("componentIds = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -476,6 +476,7 @@ const (
 							name
 							version
 							purl
+							sbomId
 						}
 						vuln {
 							id
@@ -562,8 +563,8 @@ const (
 
 	// ComponentVulnsQuery fetches component vulnerabilities with filters
 	ComponentVulnsQuery = `
-		query GetComponentVulns($first: Int, $after: String, $severity: [String!], $status: [String!], $kev: Boolean, $epss: RangeInput, $search: String, $projectIds: [Uuid!], $projectGroupIds: [Uuid!]) {
-			componentVulns(first: $first, after: $after, severity: $severity, status: $status, kev: $kev, epss: $epss, search: $search, projectIds: $projectIds, projectGroupIds: $projectGroupIds) {
+		query GetComponentVulns($first: Int, $after: String, $severity: [String!], $status: [String!], $kev: Boolean, $epss: RangeInput, $search: String, $componentIds: [Uuid!], $projectIds: [Uuid!], $projectGroupIds: [Uuid!]) {
+			componentVulns(first: $first, after: $after, severity: $severity, status: $status, kev: $kev, epss: $epss, search: $search, componentIds: $componentIds, projectIds: $projectIds, projectGroupIds: $projectGroupIds) {
 				nodes {
 					id
 					componentId

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -236,6 +236,8 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(mcp.NewTool("list_vulnerabilities",
 		mcp.WithDescription("List vulnerabilities in a version with optional filters"),
 		mcp.WithString("version_id", mcp.Required(), mcp.Description("The UUID of the version")),
+		mcp.WithString("component_id", mcp.Description("Filter to a single component UUID")),
+		mcp.WithString("purl", mcp.Description("Exact component package URL to filter by")),
 		mcp.WithString("severity", mcp.Description("Filter by severity (critical, high, medium, low)")),
 		mcp.WithString("vex_status", mcp.Description("Filter by VEX status (e.g., affected, not_affected, fixed)")),
 		mcp.WithBoolean("kev", mcp.Description("Filter to only KEV (Known Exploited Vulnerabilities)")),
@@ -294,6 +296,9 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(mcp.NewTool("search_vulnerabilities",
 		mcp.WithDescription("Search vulnerabilities across all products"),
 		mcp.WithString("search", mcp.Description("Search term (CVE ID, component name, etc.)")),
+		mcp.WithString("component_id", mcp.Description("Filter to a single component UUID")),
+		mcp.WithArray("component_ids", mcp.Description("Filter to one or more component UUIDs"), mcp.WithStringItems()),
+		mcp.WithString("purl", mcp.Description("Exact component package URL to filter by")),
 		mcp.WithString("product_id", mcp.Description("Filter by product/repository UUID")),
 		mcp.WithString("environment_id", mcp.Description("Filter by environment/project UUID")),
 		mcp.WithString("severity", mcp.Description("Filter by severity")),
@@ -305,6 +310,7 @@ func (s *Server) registerTools() {
 		mcp.WithString("match_mode", mcp.Description("How to combine filters: all (default) or any")),
 		mcp.WithBoolean("exceptional", mcp.Description("Shortcut for match_mode=any with cvss_min=9.0, epss_min=0.05, or kev=true")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
 	), s.handleSearchVulnerabilities)
 
 	// Security incident tools

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -620,6 +620,15 @@ func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.Call
 		VersionID: versionID,
 		First:     getIntParam(args, "limit", 50),
 	}
+	if componentID, ok := args["component_id"].(string); ok && componentID != "" {
+		input.ComponentIDs = []string{componentID}
+	}
+	if purl, ok := args["purl"].(string); ok {
+		if purl == "" {
+			return newToolResultError("purl must not be empty"), nil
+		}
+		input.Purl = purl
+	}
 	if severity, ok := args["severity"].(string); ok && severity != "" {
 		input.Severity = []string{severity}
 	}
@@ -652,10 +661,14 @@ func (s *Server) handleListVulnerabilities(ctx context.Context, request mcp.Call
 		if err == nil {
 			matchReasons = matchReasonsForComponentVulns(result.ComponentVulns, filters)
 			result.ComponentVulns = filterComponentVulnsByClientThresholds(result.ComponentVulns, filters)
+			result.ComponentVulns = filterComponentVulnsByComponentIdentity(result.ComponentVulns, input.ComponentIDs, input.Purl)
 			if filters.HasClientSideThresholds() {
 				result.TotalCount = len(result.ComponentVulns)
 				result.ComponentVulns = limitComponentVulns(result.ComponentVulns, input.First)
 				result.HasNextPage = result.HasNextPage || result.TotalCount > len(result.ComponentVulns)
+			}
+			if len(input.ComponentIDs) > 0 || input.Purl != "" {
+				result.TotalCount = len(result.ComponentVulns)
 			}
 		}
 	}
@@ -819,8 +832,21 @@ func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.Ca
 	input := api.ListComponentVulnsInput{
 		First: getIntParam(args, "limit", 50),
 	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
 	if search, ok := args["search"].(string); ok {
 		input.Search = search
+	}
+	input.ComponentIDs = getStringSliceParam(args, "component_ids")
+	if componentID, ok := args["component_id"].(string); ok && componentID != "" {
+		input.ComponentIDs = append(input.ComponentIDs, componentID)
+	}
+	if purl, ok := args["purl"].(string); ok {
+		if purl == "" {
+			return newToolResultError("purl must not be empty"), nil
+		}
+		input.Purl = purl
 	}
 	if severity, ok := args["severity"].(string); ok && severity != "" {
 		input.Severity = []string{severity}
@@ -851,10 +877,14 @@ func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.Ca
 		if err == nil {
 			matchReasons = matchReasonsForComponentVulns(result.ComponentVulns, filters)
 			result.ComponentVulns = filterComponentVulnsByClientThresholds(result.ComponentVulns, filters)
+			result.ComponentVulns = filterComponentVulnsByComponentIdentity(result.ComponentVulns, nil, input.Purl)
 			if filters.HasClientSideThresholds() {
 				result.TotalCount = len(result.ComponentVulns)
 				result.ComponentVulns = limitComponentVulns(result.ComponentVulns, input.First)
 				result.HasNextPage = result.HasNextPage || result.TotalCount > len(result.ComponentVulns)
+			}
+			if input.Purl != "" {
+				result.TotalCount = len(result.ComponentVulns)
 			}
 		}
 	}
@@ -866,6 +896,7 @@ func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.Ca
 		"vulnerabilities": formatComponentVulns(result.ComponentVulns, matchReasons, false),
 		"totalCount":      result.TotalCount,
 		"hasMore":         result.HasNextPage,
+		"endCursor":       result.EndCursor,
 	})
 }
 
@@ -1561,11 +1592,12 @@ func (s *Server) listVersionVulnsAny(ctx context.Context, input api.ListVersionV
 		hasMore = hasMore || result.HasNextPage
 	}
 
-	vulns := componentVulnMapValues(merged, input.First)
+	filtered := filterComponentVulnsByComponentIdentity(componentVulnMapValues(merged, 0), input.ComponentIDs, input.Purl)
+	vulns := limitComponentVulns(filtered, input.First)
 	return &api.ComponentVulnsResult{
 		ComponentVulns: vulns,
-		TotalCount:     len(merged),
-		HasNextPage:    hasMore || len(merged) > len(vulns),
+		TotalCount:     len(filtered),
+		HasNextPage:    hasMore || len(filtered) > len(vulns),
 	}, reasons, nil
 }
 
@@ -1615,11 +1647,12 @@ func (s *Server) listComponentVulnsAny(ctx context.Context, input api.ListCompon
 		hasMore = hasMore || result.HasNextPage
 	}
 
-	vulns := componentVulnMapValues(merged, input.First)
+	filtered := filterComponentVulnsByComponentIdentity(componentVulnMapValues(merged, 0), nil, input.Purl)
+	vulns := limitComponentVulns(filtered, input.First)
 	return &api.ComponentVulnsResult{
 		ComponentVulns: vulns,
-		TotalCount:     len(merged),
-		HasNextPage:    hasMore || len(merged) > len(vulns),
+		TotalCount:     len(filtered),
+		HasNextPage:    hasMore || len(filtered) > len(vulns),
 	}, reasons, nil
 }
 
@@ -1634,7 +1667,7 @@ func mergeComponentVulns(merged map[string]api.ComponentVuln, reasons map[string
 
 func componentVulnMapValues(merged map[string]api.ComponentVuln, limit int) []api.ComponentVuln {
 	if limit <= 0 {
-		limit = 50
+		limit = len(merged)
 	}
 	vulns := make([]api.ComponentVuln, 0, minInt(len(merged), limit))
 	for _, vuln := range merged {
@@ -1666,6 +1699,32 @@ func vulnerabilityAnyQueryLimit(limit int) int {
 func filterComponentVulnsByClientThresholds(vulns []api.ComponentVuln, filters vulnerabilityMetadataFilters) []api.ComponentVuln {
 	vulns = filterComponentVulnsByCvss(vulns, filters)
 	return vulns
+}
+
+func filterComponentVulnsByComponentIdentity(vulns []api.ComponentVuln, componentIDs []string, purl string) []api.ComponentVuln {
+	if len(componentIDs) == 0 && purl == "" {
+		return vulns
+	}
+	componentIDSet := make(map[string]bool, len(componentIDs))
+	for _, id := range componentIDs {
+		if id != "" {
+			componentIDSet[id] = true
+		}
+	}
+
+	filtered := make([]api.ComponentVuln, 0, len(vulns))
+	for _, vuln := range vulns {
+		if len(componentIDSet) > 0 && !componentIDSet[vuln.ComponentID] {
+			continue
+		}
+		if purl != "" {
+			if vuln.Component == nil || vuln.Component.Purl != purl {
+				continue
+			}
+		}
+		filtered = append(filtered, vuln)
+	}
+	return filtered
 }
 
 func filterComponentVulnsByCvss(vulns []api.ComponentVuln, filters vulnerabilityMetadataFilters) []api.ComponentVuln {
@@ -1733,12 +1792,17 @@ func formatComponentVulns(componentVulns []api.ComponentVuln, matchReasons map[s
 			vuln["matchReasons"] = reasons
 		}
 		if cv.Component != nil {
-			vuln["component"] = map[string]interface{}{
+			component := map[string]interface{}{
 				"id":      cv.Component.ID,
 				"name":    cv.Component.Name,
 				"version": cv.Component.Version,
 				"purl":    cv.Component.Purl,
 			}
+			if cv.Component.VersionID != "" {
+				component["sbomId"] = cv.Component.VersionID
+				component["versionId"] = cv.Component.VersionID
+			}
+			vuln["component"] = component
 		}
 		if cv.Vuln != nil {
 			vulnData := map[string]interface{}{

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -26,9 +26,10 @@ import (
 
 type fakeLynkClient struct {
 	lynkClient
-	listProductsInput     api.ListProductsInput
-	listVersionVulnsInput api.ListVersionVulnsInput
-	ticketingStatusInput  api.TicketingStatusInput
+	listProductsInput       api.ListProductsInput
+	listVersionVulnsInput   api.ListVersionVulnsInput
+	listComponentVulnsInput api.ListComponentVulnsInput
+	ticketingStatusInput    api.TicketingStatusInput
 }
 
 func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error) {
@@ -126,17 +127,37 @@ func (f *fakeLynkClient) ListVersionVulns(ctx context.Context, input api.ListVer
 	return &api.ComponentVulnsResult{
 		ComponentVulns: []api.ComponentVuln{
 			{
-				ID:        "component-vuln-1",
-				VersionID: input.VersionID,
+				ID:          "component-vuln-1",
+				ComponentID: "component-1",
+				VersionID:   input.VersionID,
 				Component: &api.VersionComponent{
-					ID:      "component-1",
-					Name:    "openssl",
-					Version: "3.0.0",
+					ID:        "component-1",
+					Name:      "openssl",
+					Version:   "3.0.0",
+					Purl:      "pkg:generic/openssl@3.0.0",
+					VersionID: input.VersionID,
 				},
 				Vuln: &api.Vuln{
 					ID:       "vuln-1",
 					VulnID:   "CVE-2026-0001",
 					Severity: "high",
+				},
+			},
+			{
+				ID:          "component-vuln-2",
+				ComponentID: "component-2",
+				VersionID:   input.VersionID,
+				Component: &api.VersionComponent{
+					ID:        "component-2",
+					Name:      "zlib",
+					Version:   "1.2.13",
+					Purl:      "pkg:generic/zlib@1.2.13",
+					VersionID: input.VersionID,
+				},
+				Vuln: &api.Vuln{
+					ID:       "vuln-2",
+					VulnID:   "CVE-2026-0002",
+					Severity: "medium",
 				},
 			},
 		},
@@ -158,6 +179,34 @@ func (f *fakeLynkClient) GetTicketingStatus(ctx context.Context, input api.Ticke
 		TicketsScannedCount: 500,
 		TicketsHasNextPage:  true,
 		TicketsEndCursor:    "tickets-cursor-2",
+	}, nil
+}
+
+func (f *fakeLynkClient) ListComponentVulns(ctx context.Context, input api.ListComponentVulnsInput) (*api.ComponentVulnsResult, error) {
+	f.listComponentVulnsInput = input
+	return &api.ComponentVulnsResult{
+		ComponentVulns: []api.ComponentVuln{
+			{
+				ID:          "component-vuln-1",
+				ComponentID: "component-1",
+				VersionID:   "version-1",
+				Component: &api.VersionComponent{
+					ID:        "component-1",
+					Name:      "openssl",
+					Version:   "3.0.0",
+					Purl:      "pkg:generic/openssl@3.0.0",
+					VersionID: "version-1",
+				},
+				Vuln: &api.Vuln{
+					ID:       "vuln-1",
+					VulnID:   "CVE-2026-0001",
+					Severity: "high",
+				},
+			},
+		},
+		TotalCount:  1,
+		HasNextPage: true,
+		EndCursor:   "search-cursor-2",
 	}, nil
 }
 
@@ -293,6 +342,114 @@ func TestHandleListVulnerabilities_PassesAfterAndReturnsEndCursor(t *testing.T) 
 	}
 	if output["hasMore"] != true {
 		t.Fatalf("hasMore = %#v, want true", output["hasMore"])
+	}
+}
+
+func TestHandleListVulnerabilities_FiltersByComponentIDAndPurl(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleListVulnerabilities(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"version_id":   "version-1",
+				"component_id": "component-1",
+				"purl":         "pkg:generic/openssl@3.0.0",
+				"limit":        10,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListVulnerabilities returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListVulnerabilities returned tool error: %#v", result.Content)
+	}
+	if !reflect.DeepEqual(client.listVersionVulnsInput.ComponentIDs, []string{"component-1"}) {
+		t.Fatalf("ComponentIDs = %#v, want component-1", client.listVersionVulnsInput.ComponentIDs)
+	}
+	if client.listVersionVulnsInput.Purl != "pkg:generic/openssl@3.0.0" {
+		t.Fatalf("Purl = %#v, want openssl purl", client.listVersionVulnsInput.Purl)
+	}
+
+	output := toolResultMap(t, result)
+	vulns := output["vulnerabilities"].([]interface{})
+	if len(vulns) != 1 {
+		t.Fatalf("len(vulnerabilities) = %d, want 1", len(vulns))
+	}
+	component := vulns[0].(map[string]interface{})["component"].(map[string]interface{})
+	if component["id"] != "component-1" || component["purl"] != "pkg:generic/openssl@3.0.0" {
+		t.Fatalf("unexpected component output: %#v", component)
+	}
+	if component["sbomId"] != "version-1" || component["versionId"] != "version-1" {
+		t.Fatalf("missing stable version identifiers: %#v", component)
+	}
+}
+
+func TestHandleListVulnerabilities_RejectsEmptyPurl(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleListVulnerabilities(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"version_id": "version-1",
+				"purl":       "",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListVulnerabilities returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected empty purl to return a tool error")
+	}
+}
+
+func TestHandleSearchVulnerabilities_FiltersComponentIDsAndPaginates(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleSearchVulnerabilities(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"component_ids": []interface{}{"component-1", "component-2"},
+				"component_id":  "component-3",
+				"after":         "search-cursor-1",
+				"limit":         25,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleSearchVulnerabilities returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleSearchVulnerabilities returned tool error: %#v", result.Content)
+	}
+	wantComponentIDs := []string{"component-1", "component-2", "component-3"}
+	if !reflect.DeepEqual(client.listComponentVulnsInput.ComponentIDs, wantComponentIDs) {
+		t.Fatalf("ComponentIDs = %#v, want %#v", client.listComponentVulnsInput.ComponentIDs, wantComponentIDs)
+	}
+	if client.listComponentVulnsInput.After != "search-cursor-1" || client.listComponentVulnsInput.First != 25 {
+		t.Fatalf("unexpected pagination input: %#v", client.listComponentVulnsInput)
+	}
+
+	output := toolResultMap(t, result)
+	if output["endCursor"] != "search-cursor-2" || output["hasMore"] != true {
+		t.Fatalf("unexpected pagination output: %#v", output)
+	}
+}
+
+func TestHandleSearchVulnerabilities_RejectsEmptyPurl(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleSearchVulnerabilities(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"purl": "",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleSearchVulnerabilities returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected empty purl to return a tool error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add component ID and exact purl filters to vulnerability MCP tools
- pass componentIds through the org-wide componentVulns GraphQL query
- return stable component identifiers and update Phase 4 docs

## Validation
- GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./...
- make build