### PR TITLE
Add bulk component VEX updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Product responses include lightweight repository import metadata when available.
 | `list_vex_statuses` | List VEX statuses with UUIDs for CVE triage |
 | `list_vex_justifications` | List VEX justifications with UUIDs for CVE triage |
 | `update_component_vex` | Update VEX data for a component vulnerability; requires `confirm=true` |
+| `bulk_update_component_vex` | Update VEX data for multiple component vulnerabilities with one shared payload; requires `confirm=true` |
 | `search_vulnerabilities` | Search across all products |
 
 `list_vulnerabilities` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.

--- a/docs/customer-mcp-gaps.md
+++ b/docs/customer-mcp-gaps.md
@@ -265,12 +265,17 @@ Expected impact: customers can enumerate all findings for a component and perfor
 ### Phase 5: Bulk VEX write
 
 - [x] Existing API bulk mutations found: `component_vex_bulk_update` and `vuln_vex_bulk_update`.
-- [ ] Add MCP client support for the existing API bulk mutation rather than designing a new API mutation first.
-- [ ] Decide whether the accepted payload should be native Interlynk update input, OpenVEX-like statements, CSAF-like statements, or a small normalized wrapper.
-- [ ] Add `bulk_update_component_vex` MCP tool with `confirm=true`.
-- [ ] Return per-item success/error results; avoid all-or-nothing unless the API guarantees transaction semantics.
-- [ ] Add partial failure tests.
-- [ ] Add rate-limit and retry behavior appropriate for bulk writes.
+- [x] Add MCP client support for the existing API bulk mutation rather than designing a new API mutation first.
+- [x] Decide whether the accepted payload should be native Interlynk update input, OpenVEX-like statements, CSAF-like statements, or a small normalized wrapper.
+- [x] Add `bulk_update_component_vex` MCP tool with `confirm=true`.
+- [x] Return per-item success/error results; avoid all-or-nothing unless the API guarantees transaction semantics.
+- [x] Add partial failure tests.
+- [x] Add rate-limit and retry behavior appropriate for bulk writes.
+
+Notes:
+- `bulk_update_component_vex` uses the existing `componentVexBulkUpdate` API mutation with a small MCP wrapper: `component_vuln_ids` plus the same shared update fields as `update_component_vex`.
+- The tool returns requested, updated, and failed counts. Updated items are returned as component vulnerability records; requested IDs missing from the API response are reported as failed with API errors when present.
+- Bulk writes are sent as one API mutation rather than a client-side loop. Existing GraphQL transient retry handling covers 5xx, HTTP 429, and network-level failures.
 
 Expected impact: triage agents can write approved dispositions in one reviewable operation instead of issuing many single-finding mutations.
 

--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -134,6 +134,29 @@ type UpdateComponentVexResult struct {
 	Errors        []string
 }
 
+// BulkUpdateComponentVexInput contains shared VEX fields for multiple component vulnerabilities.
+type BulkUpdateComponentVexInput struct {
+	ComponentVulnIDs                   []string
+	CurrentVersionID                   *string
+	VexStatusID                        *string
+	VexJustificationID                 *string
+	CDXResponseID                      *string
+	Note                               *string
+	Impact                             *string
+	Detail                             *string
+	Action                             *string
+	FixedIn                            *string
+	PropagateVex                       *bool
+	ResolutionDate                     *string
+	ComponentVulnCustomFieldAttributes *[]ComponentVulnCustomFieldAttributeInput
+}
+
+// BulkUpdateComponentVexResult contains the bulk VEX mutation result.
+type BulkUpdateComponentVexResult struct {
+	ComponentVulns []ComponentVuln
+	Errors         []string
+}
+
 // UpdateComponent updates mutable component metadata.
 func (c *Client) UpdateComponent(ctx context.Context, input UpdateComponentInput) (*UpdateComponentResult, error) {
 	vars := map[string]interface{}{
@@ -356,6 +379,86 @@ func (c *Client) UpdateComponentVex(ctx context.Context, input UpdateComponentVe
 			}
 		}
 		updateResult.ComponentVuln = componentVuln
+	}
+
+	return updateResult, nil
+}
+
+// BulkUpdateComponentVex updates VEX data for multiple component vulnerabilities.
+func (c *Client) BulkUpdateComponentVex(ctx context.Context, input BulkUpdateComponentVexInput) (*BulkUpdateComponentVexResult, error) {
+	vars := map[string]interface{}{
+		"componentVulnIds": input.ComponentVulnIDs,
+	}
+	addStringVar(vars, "currentSbomId", input.CurrentVersionID)
+	addStringVar(vars, "vexStatusId", input.VexStatusID)
+	addStringVar(vars, "vexJustificationId", input.VexJustificationID)
+	addStringVar(vars, "cdxResponseId", input.CDXResponseID)
+	addStringVar(vars, "note", input.Note)
+	addStringVar(vars, "impact", input.Impact)
+	addStringVar(vars, "detail", input.Detail)
+	addStringVar(vars, "action", input.Action)
+	addStringVar(vars, "fixedIn", input.FixedIn)
+	addBoolVar(vars, "propagateVex", input.PropagateVex)
+	addStringVar(vars, "resolutionDate", input.ResolutionDate)
+	if input.ComponentVulnCustomFieldAttributes != nil {
+		vars["componentVulnCustomFieldAttributes"] = *input.ComponentVulnCustomFieldAttributes
+	}
+
+	var result struct {
+		ComponentVexBulkUpdate struct {
+			ComponentVulns []struct {
+				ID          string `json:"id"`
+				ComponentID string `json:"componentId"`
+				VulnID      string `json:"vulnId"`
+				SbomID      string `json:"sbomId"`
+				FixedIn     string `json:"fixedIn"`
+				Detail      string `json:"detail"`
+				Impact      string `json:"impact"`
+				ActionStmt  string `json:"actionStmt"`
+				VexStatus   *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"vexStatus"`
+				VexJustification *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"vexJustification"`
+			} `json:"componentVulns"`
+			Errors []string `json:"errors"`
+		} `json:"componentVexBulkUpdate"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ComponentVexBulkUpdateMutation, vars, &result); err != nil {
+		return nil, err
+	}
+
+	mutation := result.ComponentVexBulkUpdate
+	updateResult := &BulkUpdateComponentVexResult{Errors: mutation.Errors}
+	updateResult.ComponentVulns = make([]ComponentVuln, len(mutation.ComponentVulns))
+	for i, node := range mutation.ComponentVulns {
+		componentVuln := ComponentVuln{
+			ID:          node.ID,
+			ComponentID: node.ComponentID,
+			VulnID:      node.VulnID,
+			VersionID:   node.SbomID,
+			FixedIn:     node.FixedIn,
+			Detail:      node.Detail,
+			Impact:      node.Impact,
+			ActionStmt:  node.ActionStmt,
+		}
+		if node.VexStatus != nil {
+			componentVuln.VexStatus = &VexStatus{
+				ID:   node.VexStatus.ID,
+				Name: node.VexStatus.Name,
+			}
+		}
+		if node.VexJustification != nil {
+			componentVuln.VexJustification = &VexJustification{
+				ID:   node.VexJustification.ID,
+				Name: node.VexJustification.Name,
+			}
+		}
+		updateResult.ComponentVulns[i] = componentVuln
 	}
 
 	return updateResult, nil

--- a/internal/api/mutations_test.go
+++ b/internal/api/mutations_test.go
@@ -234,3 +234,68 @@ func TestUpdateComponentVex_MapsInputsAndResults(t *testing.T) {
 		t.Fatalf("unexpected VEX result: %#v", result.ComponentVuln)
 	}
 }
+
+func TestBulkUpdateComponentVex_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentVexBulkUpdate": {
+					"componentVulns": [
+						{
+							"id": "component-vuln-1",
+							"componentId": "component-1",
+							"vulnId": "vuln-1",
+							"sbomId": "version-1",
+							"fixedIn": "1.2.3",
+							"detail": "detail",
+							"impact": "impact",
+							"actionStmt": "action",
+							"vexStatus": {"id": "status-1", "name": "not_affected"},
+							"vexJustification": {"id": "justification-1", "name": "vulnerable_code_not_present"}
+						}
+					],
+					"errors": ["component-vuln-2 failed"]
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	statusID := "status-1"
+	justificationID := "justification-1"
+	currentVersionID := "version-1"
+	note := ""
+	propagateVex := false
+	resolutionDate := "2026-05-07"
+
+	result, err := client.BulkUpdateComponentVex(context.Background(), BulkUpdateComponentVexInput{
+		ComponentVulnIDs:   []string{"component-vuln-1", "component-vuln-2"},
+		CurrentVersionID:   &currentVersionID,
+		VexStatusID:        &statusID,
+		VexJustificationID: &justificationID,
+		Note:               &note,
+		PropagateVex:       &propagateVex,
+		ResolutionDate:     &resolutionDate,
+	})
+	if err != nil {
+		t.Fatalf("BulkUpdateComponentVex returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if got := request["componentVulnIds"].([]string); len(got) != 2 || got[0] != "component-vuln-1" || got[1] != "component-vuln-2" {
+		t.Fatalf("componentVulnIds = %#v, want two requested IDs", request["componentVulnIds"])
+	}
+	if request["currentSbomId"] != "version-1" || request["vexStatusId"] != "status-1" {
+		t.Fatalf("unexpected bulk VEX variables: %#v", request)
+	}
+	if request["note"] != "" || request["propagateVex"] != false {
+		t.Fatalf("destructive bulk VEX values were not preserved: %#v", request)
+	}
+
+	if len(result.ComponentVulns) != 1 || result.ComponentVulns[0].ID != "component-vuln-1" {
+		t.Fatalf("unexpected component vulns: %#v", result.ComponentVulns)
+	}
+	if len(result.Errors) != 1 || result.Errors[0] != "component-vuln-2 failed" {
+		t.Fatalf("Errors = %#v, want partial failure", result.Errors)
+	}
+}

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -454,6 +454,35 @@ const (
 		}
 	`
 
+	// ComponentVexBulkUpdateMutation updates VEX data for multiple component vulnerabilities
+	ComponentVexBulkUpdateMutation = `
+		mutation BulkUpdateComponentVex($componentVulnIds: [Uuid!]!, $currentSbomId: Uuid, $vexStatusId: Uuid, $vexJustificationId: Uuid, $cdxResponseId: Uuid, $note: String, $impact: String, $detail: String, $action: String, $fixedIn: String, $propagateVex: Boolean, $resolutionDate: ISO8601Date, $componentVulnCustomFieldAttributes: [ComponentVulnCustomFieldAttributesInput!]) {
+			componentVexBulkUpdate(
+				input: {componentVulnIds: $componentVulnIds, currentSbomId: $currentSbomId, vexStatusId: $vexStatusId, vexJustificationId: $vexJustificationId, cdxResponseId: $cdxResponseId, note: $note, impact: $impact, detail: $detail, action: $action, fixedIn: $fixedIn, propagateVex: $propagateVex, resolutionDate: $resolutionDate, componentVulnCustomFieldAttributes: $componentVulnCustomFieldAttributes}
+			) {
+				componentVulns {
+					id
+					componentId
+					vulnId
+					sbomId
+					fixedIn
+					detail
+					impact
+					actionStmt
+					vexStatus {
+						id
+						name
+					}
+					vexJustification {
+						id
+						name
+					}
+				}
+				errors
+			}
+		}
+	`
+
 	// SbomVulnsQuery fetches vulnerabilities for an SBOM
 	SbomVulnsQuery = `
 		query GetSbomVulns($sbomId: Uuid!, $first: Int, $after: String, $severity: [String!], $status: [String!], $kev: Boolean, $epss: RangeInput, $search: String) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -40,6 +40,7 @@ type lynkClient interface {
 	GetVexStatuses(ctx context.Context) ([]api.VexStatus, error)
 	GetVexJustifications(ctx context.Context) ([]api.VexJustification, error)
 	UpdateComponentVex(ctx context.Context, input api.UpdateComponentVexInput) (*api.UpdateComponentVexResult, error)
+	BulkUpdateComponentVex(ctx context.Context, input api.BulkUpdateComponentVexInput) (*api.BulkUpdateComponentVexResult, error)
 	ListComponentVulns(ctx context.Context, input api.ListComponentVulnsInput) (*api.ComponentVulnsResult, error)
 	ListSecurityIncidents(ctx context.Context, input api.ListSecurityIncidentsInput) ([]api.SecurityIncident, error)
 	GetSecurityIncident(ctx context.Context, id string) (*api.SecurityIncident, error)
@@ -292,6 +293,34 @@ func (s *Server) registerTools() {
 			},
 		})),
 	), s.handleUpdateComponentVex)
+
+	s.mcp.AddTool(mcp.NewTool("bulk_update_component_vex",
+		mcp.WithDescription("Destructively update VEX data for multiple component vulnerabilities with one shared update payload. Requires confirm=true. Status and justification may be supplied by UUID or by name."),
+		mcp.WithArray("component_vuln_ids", mcp.Required(), mcp.Description("Component vulnerability UUIDs to update"), mcp.WithStringItems()),
+		mcp.WithBoolean("confirm", mcp.Required(), mcp.Description("Must be true to perform this destructive update")),
+		mcp.WithString("current_version_id", mcp.Description("Optional current version/SBOM context UUID")),
+		mcp.WithString("vex_status_id", mcp.Description("VEX status UUID")),
+		mcp.WithString("vex_status", mcp.Description("VEX status name (e.g., affected, not_affected, fixed); resolved to UUID automatically")),
+		mcp.WithString("vex_justification_id", mcp.Description("VEX justification UUID")),
+		mcp.WithString("vex_justification", mcp.Description("VEX justification name (e.g., vulnerable_code_not_present); resolved to UUID automatically")),
+		mcp.WithString("cdx_response_id", mcp.Description("CycloneDX response UUID")),
+		mcp.WithString("note", mcp.Description("VEX note")),
+		mcp.WithString("impact", mcp.Description("Impact statement")),
+		mcp.WithString("detail", mcp.Description("Detail statement")),
+		mcp.WithString("action", mcp.Description("Action statement")),
+		mcp.WithString("fixed_in", mcp.Description("Fixed-in value")),
+		mcp.WithBoolean("propagate_vex", mcp.Description("Propagate VEX to upstream")),
+		mcp.WithString("resolution_date", mcp.Description("Resolution date in YYYY-MM-DD format")),
+		mcp.WithArray("component_vuln_custom_field_attributes", mcp.Description("Custom field attribute objects"), mcp.Items(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id":                                   map[string]interface{}{"type": "string"},
+				"componentVulnCustomFieldDefinitionId": map[string]interface{}{"type": "string"},
+				"value":                                map[string]interface{}{"type": "string"},
+				"_destroy":                             map[string]interface{}{"type": "boolean"},
+			},
+		})),
+	), s.handleBulkUpdateComponentVex)
 
 	s.mcp.AddTool(mcp.NewTool("search_vulnerabilities",
 		mcp.WithDescription("Search vulnerabilities across all products"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -826,6 +826,57 @@ func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallT
 	return formatResult(formatComponentVuln(result.ComponentVuln))
 }
 
+func (s *Server) handleBulkUpdateComponentVex(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	if !confirmed(args) {
+		return newToolResultError("Missing required confirmation: confirm must be true for bulk_update_component_vex"), nil
+	}
+
+	componentVulnIDs := getStringSliceParam(args, "component_vuln_ids")
+	componentVulnIDs = compactStrings(componentVulnIDs)
+	if len(componentVulnIDs) == 0 {
+		return newToolResultError("Missing required parameter: component_vuln_ids"), nil
+	}
+	if !hasAnyParam(args, "vex_status_id", "vex_status", "vex_justification_id", "vex_justification", "cdx_response_id", "note", "impact", "detail", "action", "fixed_in", "propagate_vex", "resolution_date", "component_vuln_custom_field_attributes") {
+		return newToolResultError("No update fields provided"), nil
+	}
+
+	customFields, err := getComponentVulnCustomFieldInputsParam(args, "component_vuln_custom_field_attributes")
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+
+	vexStatusID, err := s.resolveVexStatusID(ctx, args)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+	vexJustificationID, err := s.resolveVexJustificationID(ctx, args)
+	if err != nil {
+		return newToolResultError(err.Error()), nil
+	}
+
+	result, err := s.client.BulkUpdateComponentVex(ctx, api.BulkUpdateComponentVexInput{
+		ComponentVulnIDs:                   componentVulnIDs,
+		CurrentVersionID:                   getStringPtrParam(args, "current_version_id"),
+		VexStatusID:                        vexStatusID,
+		VexJustificationID:                 vexJustificationID,
+		CDXResponseID:                      getStringPtrParam(args, "cdx_response_id"),
+		Note:                               getStringPtrParam(args, "note"),
+		Impact:                             getStringPtrParam(args, "impact"),
+		Detail:                             getStringPtrParam(args, "detail"),
+		Action:                             getStringPtrParam(args, "action"),
+		FixedIn:                            getStringPtrParam(args, "fixed_in"),
+		PropagateVex:                       getBoolPtrParam(args, "propagate_vex"),
+		ResolutionDate:                     getStringPtrParam(args, "resolution_date"),
+		ComponentVulnCustomFieldAttributes: customFields,
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to bulk update component VEX: %v", err)), nil
+	}
+
+	return formatResult(formatBulkComponentVexResult(componentVulnIDs, result))
+}
+
 func (s *Server) handleSearchVulnerabilities(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	filters := getVulnerabilityMetadataFilters(args)
@@ -2168,6 +2219,20 @@ func getStringSliceParam(args map[string]interface{}, key string) []string {
 	return nil
 }
 
+func compactStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
 func confirmed(args map[string]interface{}) bool {
 	confirm, ok := args["confirm"].(bool)
 	return ok && confirm
@@ -2725,6 +2790,40 @@ func formatComponentVuln(componentVuln *api.ComponentVuln) map[string]interface{
 		}
 	}
 	return result
+}
+
+func formatBulkComponentVexResult(requestedIDs []string, result *api.BulkUpdateComponentVexResult) map[string]interface{} {
+	updatedByID := make(map[string]api.ComponentVuln, len(result.ComponentVulns))
+	updated := make([]map[string]interface{}, len(result.ComponentVulns))
+	for i, componentVuln := range result.ComponentVulns {
+		updatedByID[componentVuln.ID] = componentVuln
+		updated[i] = formatComponentVuln(&componentVuln)
+	}
+
+	failed := make([]map[string]interface{}, 0)
+	for _, id := range requestedIDs {
+		if _, ok := updatedByID[id]; ok {
+			continue
+		}
+		failure := map[string]interface{}{
+			"componentVulnId": id,
+		}
+		if len(result.Errors) > 0 {
+			failure["errors"] = result.Errors
+		} else {
+			failure["errors"] = []string{"API returned no updated component vulnerability for requested ID"}
+		}
+		failed = append(failed, failure)
+	}
+
+	return map[string]interface{}{
+		"requestedCount": len(requestedIDs),
+		"updatedCount":   len(updated),
+		"failedCount":    len(failed),
+		"updated":        updated,
+		"failed":         failed,
+		"errors":         result.Errors,
+	}
 }
 
 func formatDoctorResults(versionID string, result *api.DoctorResultsResult) map[string]interface{} {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -26,10 +26,11 @@ import (
 
 type fakeLynkClient struct {
 	lynkClient
-	listProductsInput       api.ListProductsInput
-	listVersionVulnsInput   api.ListVersionVulnsInput
-	listComponentVulnsInput api.ListComponentVulnsInput
-	ticketingStatusInput    api.TicketingStatusInput
+	listProductsInput           api.ListProductsInput
+	listVersionVulnsInput       api.ListVersionVulnsInput
+	listComponentVulnsInput     api.ListComponentVulnsInput
+	bulkUpdateComponentVexInput api.BulkUpdateComponentVexInput
+	ticketingStatusInput        api.TicketingStatusInput
 }
 
 func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error) {
@@ -207,6 +208,42 @@ func (f *fakeLynkClient) ListComponentVulns(ctx context.Context, input api.ListC
 		TotalCount:  1,
 		HasNextPage: true,
 		EndCursor:   "search-cursor-2",
+	}, nil
+}
+
+func (f *fakeLynkClient) GetVexStatuses(ctx context.Context) ([]api.VexStatus, error) {
+	return []api.VexStatus{
+		{ID: "status-1", Name: "not_affected"},
+	}, nil
+}
+
+func (f *fakeLynkClient) GetVexJustifications(ctx context.Context) ([]api.VexJustification, error) {
+	return []api.VexJustification{
+		{ID: "justification-1", Name: "vulnerable_code_not_present"},
+	}, nil
+}
+
+func (f *fakeLynkClient) BulkUpdateComponentVex(ctx context.Context, input api.BulkUpdateComponentVexInput) (*api.BulkUpdateComponentVexResult, error) {
+	f.bulkUpdateComponentVexInput = input
+	return &api.BulkUpdateComponentVexResult{
+		ComponentVulns: []api.ComponentVuln{
+			{
+				ID:          "component-vuln-1",
+				ComponentID: "component-1",
+				VulnID:      "vuln-1",
+				VersionID:   "version-1",
+				FixedIn:     "1.2.3",
+				VexStatus: &api.VexStatus{
+					ID:   "status-1",
+					Name: "not_affected",
+				},
+				VexJustification: &api.VexJustification{
+					ID:   "justification-1",
+					Name: "vulnerable_code_not_present",
+				},
+			},
+		},
+		Errors: []string{"component-vuln-2 failed"},
 	}, nil
 }
 
@@ -450,6 +487,97 @@ func TestHandleSearchVulnerabilities_RejectsEmptyPurl(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected empty purl to return a tool error")
+	}
+}
+
+func TestHandleBulkUpdateComponentVex_RequiresConfirm(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleBulkUpdateComponentVex(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"component_vuln_ids": []interface{}{"component-vuln-1"},
+				"vex_status_id":      "status-1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleBulkUpdateComponentVex returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected missing confirm to return a tool error")
+	}
+}
+
+func TestHandleBulkUpdateComponentVex_RejectsEmptyIDs(t *testing.T) {
+	server := &Server{client: &fakeLynkClient{}}
+	result, err := server.handleBulkUpdateComponentVex(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"confirm":            true,
+				"component_vuln_ids": []interface{}{" "},
+				"vex_status_id":      "status-1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleBulkUpdateComponentVex returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected empty component_vuln_ids to return a tool error")
+	}
+}
+
+func TestHandleBulkUpdateComponentVex_ResolvesNamesAndReturnsPartialFailures(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleBulkUpdateComponentVex(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"confirm":            true,
+				"component_vuln_ids": []interface{}{"component-vuln-1", "component-vuln-2"},
+				"current_version_id": "version-1",
+				"vex_status":         "not affected",
+				"vex_justification":  "vulnerable code not present",
+				"fixed_in":           "1.2.3",
+				"propagate_vex":      false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleBulkUpdateComponentVex returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleBulkUpdateComponentVex returned tool error: %#v", result.Content)
+	}
+
+	input := client.bulkUpdateComponentVexInput
+	if !reflect.DeepEqual(input.ComponentVulnIDs, []string{"component-vuln-1", "component-vuln-2"}) {
+		t.Fatalf("ComponentVulnIDs = %#v, want requested IDs", input.ComponentVulnIDs)
+	}
+	if input.CurrentVersionID == nil || *input.CurrentVersionID != "version-1" {
+		t.Fatalf("CurrentVersionID = %#v, want version-1", input.CurrentVersionID)
+	}
+	if input.VexStatusID == nil || *input.VexStatusID != "status-1" {
+		t.Fatalf("VexStatusID = %#v, want status-1", input.VexStatusID)
+	}
+	if input.VexJustificationID == nil || *input.VexJustificationID != "justification-1" {
+		t.Fatalf("VexJustificationID = %#v, want justification-1", input.VexJustificationID)
+	}
+	if input.PropagateVex == nil || *input.PropagateVex {
+		t.Fatalf("PropagateVex = %#v, want false", input.PropagateVex)
+	}
+
+	output := toolResultMap(t, result)
+	if output["requestedCount"] != float64(2) || output["updatedCount"] != float64(1) || output["failedCount"] != float64(1) {
+		t.Fatalf("unexpected counts: %#v", output)
+	}
+	updated := output["updated"].([]interface{})
+	if len(updated) != 1 || updated[0].(map[string]interface{})["id"] != "component-vuln-1" {
+		t.Fatalf("unexpected updated entries: %#v", updated)
+	}
+	failed := output["failed"].([]interface{})
+	if len(failed) != 1 || failed[0].(map[string]interface{})["componentVulnId"] != "component-vuln-2" {
+		t.Fatalf("unexpected failed entries: %#v", failed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add API client support for the existing componentVexBulkUpdate mutation
- add bulk_update_component_vex MCP tool with confirm=true and shared update fields
- return requested/updated/failed counts with updated records and failed requested IDs
- mark Phase 5 completed in docs/customer-mcp-gaps.md

## Validation
- GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./...
- make build