### PR TITLE
Add version discovery and CycloneDX VEX export

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,12 +347,16 @@ Product responses include lightweight repository import metadata when available.
 |------|-------------|
 | `list_versions` | List versions in an environment |
 | `get_version` | Get version details with statistics |
+| `find_version` | Find versions by exact version string with optional product/environment disambiguation |
+| `export_cyclonedx_vex` | Export CycloneDX SBOM content with vulnerabilities for VEX workflows |
 | `list_doctor_results` | List SBOM Doctor findings for a version |
 | `compare_versions` | Compare two versions and show drift analysis |
 | `list_components` | List components in a version |
 | `get_component` | Get component details |
 | `update_component` | Update component metadata; requires `confirm=true` |
 | `update_component_supplier` | Update component supplier metadata; requires `confirm=true` |
+
+`get_version` can include a per-component vulnerability summary with `include_component_vuln_summary=true`. `export_cyclonedx_vex` returns `ready`, processing status, filename/content type, content length, and content unless `include_content=false`.
 
 ### Vulnerabilities & VEX
 
@@ -369,6 +373,8 @@ Product responses include lightweight repository import metadata when available.
 `list_vulnerabilities` supports cursor pagination with `limit` and `after`. Responses include `hasMore` and `endCursor`; pass `endCursor` as `after` to fetch the next page.
 
 `list_vulnerabilities` can filter a version by `component_id` or exact component `purl`. `search_vulnerabilities` can filter across the organization by `component_id`, `component_ids`, or exact `purl`, and supports `after`/`endCursor` pagination.
+
+Vulnerability responses include both `fixedIn` and `fixedVersions`; prefer `fixedVersions` when present because it is structured.
 
 ### Supply-Chain Security Incidents
 

--- a/docs/customer-mcp-gaps.md
+++ b/docs/customer-mcp-gaps.md
@@ -281,18 +281,24 @@ Expected impact: triage agents can write approved dispositions in one reviewable
 
 ### Phase 6: Data-quality and discovery improvements
 
-- [ ] Investigate why `fixedIn` is usually empty even though MCP requests it.
-- [ ] Confirm whether `fixedVersions` has better population and should be emphasized in responses.
-- [ ] Add direct version lookup by product name plus version string:
+- [x] Investigate why `fixedIn` is usually empty even though MCP requests it.
+- [x] Confirm whether `fixedVersions` has better population and should be emphasized in responses.
+- [x] Add direct version lookup by product name plus version string:
   - API has org-wide `project_versions` search by version string.
   - MCP still needs product/environment disambiguation for an exact lookup helper.
-- [ ] Add per-component vulnerability summary to `get_version`:
+- [x] Add per-component vulnerability summary to `get_version`:
   - Prefer API-side aggregation for performance.
   - Include severity counts and total count per component.
-- [ ] Add programmatic CycloneDX VEX export:
+- [x] Add programmatic CycloneDX VEX export:
   - API has `Sbom.download`; verify whether `include_vulns` plus CycloneDX spec/spec version satisfies CycloneDX VEX needs.
   - Return readiness/status plus content metadata or download content according to API behavior.
   - Include permission and expiration behavior in docs.
+
+Notes:
+- `fixedIn` is a VEX/edit field on `ComponentVuln` and may be empty when no disposition-specific fixed-in value has been recorded. The API also exposes `fixedVersions` from vulnerability intelligence; MCP now returns it alongside `fixedIn` and docs recommend preferring it when populated.
+- `find_version` uses the API's org-wide `projectVersions(search: ...)` resolver, then filters exact version string plus optional product and environment names.
+- `get_version` can include per-component vulnerability summaries with `include_component_vuln_summary=true`; summaries use the API's component `stats.vulnStats` and `stats.vulnTotalCount`.
+- `export_cyclonedx_vex` calls `Sbom.download` with `spec=CycloneDX`, `includeVulns=true`, and `requireCompleted=[VULN_SCAN]` by default. The API returns readiness, processing status, metadata, and inline content when ready; access and expiration behavior are controlled by the API's SBOM download authorization.
 
 ## Priority Recommendation
 

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -46,6 +46,12 @@ type VersionStats struct {
 	VulnStats         map[string]interface{}
 }
 
+// ComponentVulnerabilitySummary contains vulnerability counts for a component.
+type ComponentVulnerabilitySummary struct {
+	TotalCount int
+	Stats      map[string]interface{}
+}
+
 // VersionComponent represents a component in a version
 type VersionComponent struct {
 	ID           string
@@ -70,6 +76,7 @@ type VersionComponent struct {
 	VersionID    string
 	UpdatedAt    time.Time
 	VersionInfo  *Version
+	VulnSummary  *ComponentVulnerabilitySummary
 }
 
 // VersionsResult represents the result of listing versions
@@ -88,6 +95,31 @@ type ComponentsResult struct {
 	EndCursor   string
 }
 
+// VersionSearchInput contains parameters for searching versions across the organization.
+type VersionSearchInput struct {
+	Search string
+	First  int
+	After  string
+}
+
+// DownloadSBOMInput contains parameters for SBOM downloads.
+type DownloadSBOMInput struct {
+	VersionID        string
+	Spec             string
+	SpecVersion      string
+	IncludeVulns     *bool
+	RequireCompleted []string
+}
+
+// DownloadSBOMResult contains SBOM download readiness, metadata, and content.
+type DownloadSBOMResult struct {
+	Ready            bool
+	Filename         string
+	ContentType      string
+	Content          string
+	ProcessingStatus map[string]string
+}
+
 // VersionDiff represents a diff entry between two versions
 type VersionDiff struct {
 	DiffType           string
@@ -96,6 +128,75 @@ type VersionDiff struct {
 	SubjectComponentID string
 	TargetComponent    *VersionComponent
 	TargetComponentID  string
+}
+
+type versionNode struct {
+	ID             string    `json:"id"`
+	ProjectVersion string    `json:"projectVersion"`
+	Spec           string    `json:"spec"`
+	SpecVersion    string    `json:"specVersion"`
+	Format         string    `json:"format"`
+	Lifecycle      string    `json:"lifecycle"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+	ProjectID      string    `json:"projectId"`
+	Stats          *struct {
+		CompCount         int                    `json:"compCount"`
+		CompPurlCount     int                    `json:"compPurlCount"`
+		CompCpeCount      int                    `json:"compCpeCount"`
+		CompLicenseCount  int                    `json:"compLicenseCount"`
+		CompSupplierCount int                    `json:"compSupplierCount"`
+		VulnStats         map[string]interface{} `json:"vulnStats"`
+	} `json:"stats"`
+	Project *struct {
+		ID             string `json:"id"`
+		Name           string `json:"name"`
+		ProjectGroupID string `json:"projectGroupId"`
+		ProjectGroup   *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"projectGroup"`
+	} `json:"project"`
+}
+
+func mapVersionNode(n versionNode) Version {
+	var stats *VersionStats
+	if n.Stats != nil {
+		stats = &VersionStats{
+			CompCount:         n.Stats.CompCount,
+			CompPurlCount:     n.Stats.CompPurlCount,
+			CompCpeCount:      n.Stats.CompCpeCount,
+			CompLicenseCount:  n.Stats.CompLicenseCount,
+			CompSupplierCount: n.Stats.CompSupplierCount,
+			VulnStats:         n.Stats.VulnStats,
+		}
+	}
+	version := Version{
+		ID:            n.ID,
+		Version:       n.ProjectVersion,
+		Spec:          n.Spec,
+		SpecVersion:   n.SpecVersion,
+		Format:        n.Format,
+		Lifecycle:     n.Lifecycle,
+		CreatedAt:     n.CreatedAt,
+		UpdatedAt:     n.UpdatedAt,
+		EnvironmentID: n.ProjectID,
+		Stats:         stats,
+	}
+	if n.Project != nil {
+		version.Environment = &Environment{
+			ID:        n.Project.ID,
+			Name:      n.Project.Name,
+			ProductID: n.Project.ProjectGroupID,
+		}
+		if n.Project.ProjectGroup != nil {
+			version.Environment.Product = &Product{
+				ID:   n.Project.ProjectGroup.ID,
+				Name: n.Project.ProjectGroup.Name,
+			}
+		}
+	}
+	return version
 }
 
 // ListVersionsInput contains parameters for listing versions
@@ -193,6 +294,48 @@ func (c *Client) ListVersions(ctx context.Context, input ListVersionsInput) (*Ve
 	}, nil
 }
 
+// SearchVersions searches versions across the organization by version string.
+func (c *Client) SearchVersions(ctx context.Context, input VersionSearchInput) (*VersionsResult, error) {
+	vars := map[string]interface{}{
+		"search": input.Search,
+	}
+	if input.First > 0 {
+		vars["first"] = input.First
+	} else {
+		vars["first"] = 20
+	}
+	if input.After != "" {
+		vars["after"] = input.After
+	}
+
+	var result struct {
+		ProjectVersions struct {
+			Nodes      []versionNode `json:"nodes"`
+			TotalCount int           `json:"totalCount"`
+			PageInfo   struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"projectVersions"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ProjectVersionsSearchQuery, vars, &result); err != nil {
+		return nil, err
+	}
+
+	versions := make([]Version, len(result.ProjectVersions.Nodes))
+	for i, n := range result.ProjectVersions.Nodes {
+		versions[i] = mapVersionNode(n)
+	}
+
+	return &VersionsResult{
+		Versions:    versions,
+		TotalCount:  result.ProjectVersions.TotalCount,
+		HasNextPage: result.ProjectVersions.PageInfo.HasNextPage,
+		EndCursor:   result.ProjectVersions.PageInfo.EndCursor,
+	}, nil
+}
+
 // GetVersion fetches a single version by ID
 func (c *Client) GetVersion(ctx context.Context, id string) (*Version, error) {
 	vars := map[string]interface{}{
@@ -261,6 +404,64 @@ func (c *Client) GetVersion(ctx context.Context, id string) (*Version, error) {
 	}, nil
 }
 
+// DownloadSBOM fetches SBOM download readiness, metadata, and content.
+func (c *Client) DownloadSBOM(ctx context.Context, input DownloadSBOMInput) (*DownloadSBOMResult, error) {
+	vars := map[string]interface{}{
+		"sbomId": input.VersionID,
+	}
+	if input.Spec != "" {
+		vars["spec"] = input.Spec
+	}
+	if input.SpecVersion != "" {
+		vars["specVersion"] = input.SpecVersion
+	}
+	if input.IncludeVulns != nil {
+		vars["includeVulns"] = *input.IncludeVulns
+	}
+	if len(input.RequireCompleted) > 0 {
+		vars["requireCompleted"] = input.RequireCompleted
+	}
+
+	var result struct {
+		Sbom struct {
+			Download *struct {
+				Ready            bool   `json:"ready"`
+				Filename         string `json:"filename"`
+				ContentType      string `json:"contentType"`
+				Content          string `json:"content"`
+				ProcessingStatus *struct {
+					Automation string `json:"automation"`
+					PolicyScan string `json:"policyScan"`
+					VulnScan   string `json:"vulnScan"`
+				} `json:"processingStatus"`
+			} `json:"download"`
+		} `json:"sbom"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.SbomDownloadQuery, vars, &result); err != nil {
+		return nil, err
+	}
+	if result.Sbom.Download == nil {
+		return &DownloadSBOMResult{}, nil
+	}
+
+	download := &DownloadSBOMResult{
+		Ready:       result.Sbom.Download.Ready,
+		Filename:    result.Sbom.Download.Filename,
+		ContentType: result.Sbom.Download.ContentType,
+		Content:     result.Sbom.Download.Content,
+	}
+	if result.Sbom.Download.ProcessingStatus != nil {
+		download.ProcessingStatus = map[string]string{
+			"automation": result.Sbom.Download.ProcessingStatus.Automation,
+			"policyScan": result.Sbom.Download.ProcessingStatus.PolicyScan,
+			"vulnScan":   result.Sbom.Download.ProcessingStatus.VulnScan,
+		}
+	}
+
+	return download, nil
+}
+
 // ListComponentsInput contains parameters for listing components
 type ListComponentsInput struct {
 	VersionID string
@@ -298,19 +499,23 @@ func (c *Client) ListComponents(ctx context.Context, input ListComponentsInput) 
 		Sbom struct {
 			Components struct {
 				Nodes []struct {
-					ID          string    `json:"id"`
-					Name        string    `json:"name"`
-					Version     string    `json:"version"`
-					Kind        string    `json:"kind"`
-					Purl        string    `json:"purl"`
-					Cpes        []string  `json:"cpes"`
-					LicensesExp string    `json:"licensesExp"`
-					Group       string    `json:"group"`
-					Description string    `json:"description"`
-					Primary     bool      `json:"primary"`
-					Internal    bool      `json:"internal"`
-					SbomID      string    `json:"sbomId"`
-					UpdatedAt   time.Time `json:"updatedAt"`
+					ID          string   `json:"id"`
+					Name        string   `json:"name"`
+					Version     string   `json:"version"`
+					Kind        string   `json:"kind"`
+					Purl        string   `json:"purl"`
+					Cpes        []string `json:"cpes"`
+					LicensesExp string   `json:"licensesExp"`
+					Group       string   `json:"group"`
+					Description string   `json:"description"`
+					Primary     bool     `json:"primary"`
+					Internal    bool     `json:"internal"`
+					SbomID      string   `json:"sbomId"`
+					Stats       *struct {
+						VulnStats      map[string]interface{} `json:"vulnStats"`
+						VulnTotalCount int                    `json:"vulnTotalCount"`
+					} `json:"stats"`
+					UpdatedAt time.Time `json:"updatedAt"`
 				} `json:"nodes"`
 				TotalCount int `json:"totalCount"`
 				PageInfo   struct {
@@ -342,6 +547,12 @@ func (c *Client) ListComponents(ctx context.Context, input ListComponentsInput) 
 			VersionID:   n.SbomID,
 			UpdatedAt:   n.UpdatedAt,
 		}
+		if n.Stats != nil {
+			components[i].VulnSummary = &ComponentVulnerabilitySummary{
+				TotalCount: n.Stats.VulnTotalCount,
+				Stats:      n.Stats.VulnStats,
+			}
+		}
 	}
 
 	return &ComponentsResult{
@@ -361,20 +572,24 @@ func (c *Client) GetComponent(ctx context.Context, id, versionID string) (*Versi
 
 	var result struct {
 		Component struct {
-			ID          string    `json:"id"`
-			Name        string    `json:"name"`
-			Version     string    `json:"version"`
-			Kind        string    `json:"kind"`
-			Purl        string    `json:"purl"`
-			Cpes        []string  `json:"cpes"`
-			LicensesExp string    `json:"licensesExp"`
-			Group       string    `json:"group"`
-			Description string    `json:"description"`
-			Primary     bool      `json:"primary"`
-			Internal    bool      `json:"internal"`
-			SbomID      string    `json:"sbomId"`
-			UpdatedAt   time.Time `json:"updatedAt"`
-			Sbom        struct {
+			ID          string   `json:"id"`
+			Name        string   `json:"name"`
+			Version     string   `json:"version"`
+			Kind        string   `json:"kind"`
+			Purl        string   `json:"purl"`
+			Cpes        []string `json:"cpes"`
+			LicensesExp string   `json:"licensesExp"`
+			Group       string   `json:"group"`
+			Description string   `json:"description"`
+			Primary     bool     `json:"primary"`
+			Internal    bool     `json:"internal"`
+			SbomID      string   `json:"sbomId"`
+			Stats       *struct {
+				VulnStats      map[string]interface{} `json:"vulnStats"`
+				VulnTotalCount int                    `json:"vulnTotalCount"`
+			} `json:"stats"`
+			UpdatedAt time.Time `json:"updatedAt"`
+			Sbom      struct {
 				ID             string `json:"id"`
 				ProjectVersion string `json:"projectVersion"`
 				Project        struct {
@@ -389,7 +604,7 @@ func (c *Client) GetComponent(ctx context.Context, id, versionID string) (*Versi
 		return nil, err
 	}
 
-	return &VersionComponent{
+	component := &VersionComponent{
 		ID:          result.Component.ID,
 		Name:        result.Component.Name,
 		Version:     result.Component.Version,
@@ -411,7 +626,14 @@ func (c *Client) GetComponent(ctx context.Context, id, versionID string) (*Versi
 				Name: result.Component.Sbom.Project.Name,
 			},
 		},
-	}, nil
+	}
+	if result.Component.Stats != nil {
+		component.VulnSummary = &ComponentVulnerabilitySummary{
+			TotalCount: result.Component.Stats.VulnTotalCount,
+			Stats:      result.Component.Stats.VulnStats,
+		}
+	}
+	return component, nil
 }
 
 // CompareVersions compares two versions and returns the differences

--- a/internal/api/versions_test.go
+++ b/internal/api/versions_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSearchVersions_MapsProductEnvironmentAndPagination(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"projectVersions": {
+					"nodes": [
+						{
+							"id": "version-1",
+							"projectVersion": "1.0.0",
+							"spec": "CycloneDX",
+							"specVersion": "1.6",
+							"format": "json",
+							"lifecycle": "released",
+							"createdAt": "2026-06-01T00:00:00Z",
+							"updatedAt": "2026-06-02T00:00:00Z",
+							"projectId": "env-1",
+							"stats": {
+								"compCount": 2,
+								"compPurlCount": 2,
+								"compCpeCount": 1,
+								"compLicenseCount": 2,
+								"compSupplierCount": 1,
+								"vulnStats": {"critical": 1}
+							},
+							"project": {
+								"id": "env-1",
+								"name": "production",
+								"projectGroupId": "product-1",
+								"projectGroup": {
+									"id": "product-1",
+									"name": "Product 1"
+								}
+							}
+						}
+					],
+					"totalCount": 1,
+					"pageInfo": {
+						"hasNextPage": false,
+						"endCursor": "cursor-1"
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.SearchVersions(context.Background(), VersionSearchInput{
+		Search: "1.0.0",
+		First:  25,
+		After:  "cursor-0",
+	})
+	if err != nil {
+		t.Fatalf("SearchVersions returned error: %v", err)
+	}
+
+	request := gql.requests[0]
+	if request["search"] != "1.0.0" || request["first"] != 25 || request["after"] != "cursor-0" {
+		t.Fatalf("unexpected request variables: %#v", request)
+	}
+	if len(result.Versions) != 1 {
+		t.Fatalf("len(Versions) = %d, want 1", len(result.Versions))
+	}
+	version := result.Versions[0]
+	if version.Environment == nil || version.Environment.Name != "production" {
+		t.Fatalf("unexpected environment: %#v", version.Environment)
+	}
+	if version.Environment.Product == nil || version.Environment.Product.Name != "Product 1" {
+		t.Fatalf("unexpected product: %#v", version.Environment.Product)
+	}
+	if version.Stats == nil || version.Stats.VulnStats["critical"] != float64(1) {
+		t.Fatalf("unexpected stats: %#v", version.Stats)
+	}
+}
+
+func TestListComponents_MapsVulnerabilitySummary(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"sbom": {
+					"components": {
+						"nodes": [
+							{
+								"id": "component-1",
+								"name": "openssl",
+								"version": "3.0.0",
+								"kind": "library",
+								"purl": "pkg:generic/openssl@3.0.0",
+								"cpes": [],
+								"licensesExp": "Apache-2.0",
+								"group": "",
+								"description": "",
+								"primary": false,
+								"internal": false,
+								"sbomId": "version-1",
+								"stats": {
+									"vulnStats": {"high": 2},
+									"vulnTotalCount": 2
+								},
+								"updatedAt": "2026-06-02T00:00:00Z"
+							}
+						],
+						"totalCount": 1,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListComponents(context.Background(), ListComponentsInput{VersionID: "version-1", First: 10})
+	if err != nil {
+		t.Fatalf("ListComponents returned error: %v", err)
+	}
+	if len(result.Components) != 1 || result.Components[0].VulnSummary == nil {
+		t.Fatalf("expected component vuln summary: %#v", result.Components)
+	}
+	summary := result.Components[0].VulnSummary
+	if summary.TotalCount != 2 || summary.Stats["high"] != float64(2) {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+}
+
+func TestDownloadSBOM_MapsCycloneDXDownload(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"sbom": {
+					"download": {
+						"ready": true,
+						"filename": "bom.cdx.json",
+						"contentType": "application/json",
+						"content": "{\"bomFormat\":\"CycloneDX\"}",
+						"processingStatus": {
+							"automation": "FINISHED",
+							"policyScan": "FINISHED",
+							"vulnScan": "FINISHED"
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	includeVulns := true
+	result, err := client.DownloadSBOM(context.Background(), DownloadSBOMInput{
+		VersionID:        "version-1",
+		Spec:             "CycloneDX",
+		SpecVersion:      "1.6",
+		IncludeVulns:     &includeVulns,
+		RequireCompleted: []string{"VULN_SCAN"},
+	})
+	if err != nil {
+		t.Fatalf("DownloadSBOM returned error: %v", err)
+	}
+	request := gql.requests[0]
+	if request["spec"] != "CycloneDX" || request["includeVulns"] != true {
+		t.Fatalf("unexpected download variables: %#v", request)
+	}
+	if result.Filename != "bom.cdx.json" || !result.Ready || result.ProcessingStatus["vulnScan"] != "FINISHED" {
+		t.Fatalf("unexpected download result: %#v", result)
+	}
+}

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -277,6 +277,47 @@ const (
 		}
 	`
 
+	// ProjectVersionsSearchQuery searches SBOM versions across the organization
+	ProjectVersionsSearchQuery = `
+		query SearchProjectVersions($search: String!, $first: Int, $after: String) {
+			projectVersions(search: $search, first: $first, after: $after) {
+				nodes {
+					id
+					projectVersion
+					spec
+					specVersion
+					format
+					lifecycle
+					createdAt
+					updatedAt
+					projectId
+					stats {
+						compCount
+						compPurlCount
+						compCpeCount
+						compLicenseCount
+						compSupplierCount
+						vulnStats
+					}
+					project {
+						id
+						name
+						projectGroupId
+						projectGroup {
+							id
+							name
+						}
+					}
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	`
+
 	// SbomQuery fetches a single SBOM by ID
 	SbomQuery = `
 		query GetSbom($sbomId: Uuid!) {
@@ -325,6 +366,10 @@ const (
 						primary
 						internal
 						sbomId
+						stats {
+							vulnStats
+							vulnTotalCount
+						}
 						updatedAt
 					}
 					totalCount
@@ -355,6 +400,10 @@ const (
 				primary
 				internal
 				sbomId
+				stats {
+					vulnStats
+					vulnTotalCount
+				}
 				updatedAt
 				sbom {
 					id
@@ -362,6 +411,25 @@ const (
 					project {
 						id
 						name
+					}
+				}
+			}
+		}
+	`
+
+	// SbomDownloadQuery fetches SBOM download readiness and content
+	SbomDownloadQuery = `
+		query DownloadSbom($sbomId: Uuid!, $spec: SbomSpec, $specVersion: String, $includeVulns: Boolean, $requireCompleted: [SbomProcessingStageEnum!]) {
+			sbom(sbomId: $sbomId) {
+				download(sbomId: $sbomId, spec: $spec, specVersion: $specVersion, includeVulns: $includeVulns, requireCompleted: $requireCompleted) {
+					ready
+					filename
+					contentType
+					content
+					processingStatus {
+						automation
+						policyScan
+						vulnScan
 					}
 				}
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,6 +29,8 @@ type lynkClient interface {
 	GetProduct(ctx context.Context, id string) (*api.Product, error)
 	ListVersions(ctx context.Context, input api.ListVersionsInput) (*api.VersionsResult, error)
 	GetVersion(ctx context.Context, id string) (*api.Version, error)
+	SearchVersions(ctx context.Context, input api.VersionSearchInput) (*api.VersionsResult, error)
+	DownloadSBOM(ctx context.Context, input api.DownloadSBOMInput) (*api.DownloadSBOMResult, error)
 	ListDoctorResults(ctx context.Context, input api.ListDoctorResultsInput) (*api.DoctorResultsResult, error)
 	CompareVersions(ctx context.Context, sourceVersionID, targetVersionID string) ([]api.VersionDiff, error)
 	ListComponents(ctx context.Context, input api.ListComponentsInput) (*api.ComponentsResult, error)
@@ -142,7 +144,25 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(mcp.NewTool("get_version",
 		mcp.WithDescription("Get details of a specific version including statistics"),
 		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the version")),
+		mcp.WithBoolean("include_component_vuln_summary", mcp.Description("Include per-component vulnerability summary from component stats")),
+		mcp.WithNumber("component_summary_limit", mcp.Description("Maximum number of component summaries to return when included (default: 100)")),
 	), s.handleGetVersion)
+
+	s.mcp.AddTool(mcp.NewTool("find_version",
+		mcp.WithDescription("Find versions by exact version string with optional product and environment name disambiguation"),
+		mcp.WithString("version", mcp.Required(), mcp.Description("Exact version string to find")),
+		mcp.WithString("product_name", mcp.Description("Optional exact product/repository name to disambiguate")),
+		mcp.WithString("environment_name", mcp.Description("Optional exact environment/project name to disambiguate")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of candidate versions to inspect (default: 50)")),
+	), s.handleFindVersion)
+
+	s.mcp.AddTool(mcp.NewTool("export_cyclonedx_vex",
+		mcp.WithDescription("Export a CycloneDX SBOM with vulnerabilities for VEX workflows. Returns readiness/status, metadata, and optionally content."),
+		mcp.WithString("version_id", mcp.Required(), mcp.Description("The UUID of the version/SBOM to export")),
+		mcp.WithString("spec_version", mcp.Description("CycloneDX spec version (default: 1.6)")),
+		mcp.WithBoolean("include_content", mcp.Description("Include download content in the response (default: true)")),
+		mcp.WithBoolean("require_vuln_scan_complete", mcp.Description("Require vulnerability scanning to be finished before content is returned (default: true)")),
+	), s.handleExportCycloneDXVex)
 
 	s.mcp.AddTool(mcp.NewTool("list_doctor_results",
 		mcp.WithDescription("List SBOM Doctor findings for a version"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -239,23 +239,7 @@ func (s *Server) handleListVersions(ctx context.Context, request mcp.CallToolReq
 
 	versions := make([]map[string]interface{}, len(result.Versions))
 	for i, v := range result.Versions {
-		versionData := map[string]interface{}{
-			"id":          v.ID,
-			"version":     v.Version,
-			"spec":        v.Spec,
-			"specVersion": v.SpecVersion,
-			"format":      v.Format,
-			"lifecycle":   v.Lifecycle,
-			"createdAt":   v.CreatedAt,
-			"updatedAt":   v.UpdatedAt,
-		}
-		if v.Stats != nil {
-			versionData["stats"] = map[string]interface{}{
-				"componentCount": v.Stats.CompCount,
-				"vulnStats":      v.Stats.VulnStats,
-			}
-		}
-		versions[i] = versionData
+		versions[i] = formatVersionSummary(&v)
 	}
 
 	return formatResult(map[string]interface{}{
@@ -299,6 +283,17 @@ func (s *Server) handleGetVersion(ctx context.Context, request mcp.CallToolReque
 			"vulnerabilities":       version.Stats.VulnStats,
 		}
 	}
+	if includeSummary, ok := args["include_component_vuln_summary"].(bool); ok && includeSummary {
+		limit := getIntParam(args, "component_summary_limit", 100)
+		components, err := s.client.ListComponents(ctx, api.ListComponentsInput{
+			VersionID: id,
+			First:     limit,
+		})
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("Failed to list component vulnerability summaries: %v", err)), nil
+		}
+		result["componentVulnerabilitySummary"] = formatComponentVulnerabilitySummaries(components)
+	}
 
 	if version.Environment != nil {
 		result["environment"] = map[string]interface{}{
@@ -309,6 +304,103 @@ func (s *Server) handleGetVersion(ctx context.Context, request mcp.CallToolReque
 	}
 
 	return formatResult(result)
+}
+
+func (s *Server) handleFindVersion(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	versionString, ok := args["version"].(string)
+	if !ok || versionString == "" {
+		return newToolResultError("Missing required parameter: version"), nil
+	}
+
+	searchResult, err := s.client.SearchVersions(ctx, api.VersionSearchInput{
+		Search: versionString,
+		First:  getIntParam(args, "limit", 50),
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to find version: %v", err)), nil
+	}
+
+	productName := strings.TrimSpace(stringParam(args, "product_name"))
+	environmentName := strings.TrimSpace(stringParam(args, "environment_name"))
+	matches := make([]map[string]interface{}, 0, len(searchResult.Versions))
+	for _, version := range searchResult.Versions {
+		if version.Version != versionString {
+			continue
+		}
+		if productName != "" {
+			if version.Environment == nil || version.Environment.Product == nil || !sameName(version.Environment.Product.Name, productName) {
+				continue
+			}
+		}
+		if environmentName != "" {
+			if version.Environment == nil || !sameName(version.Environment.Name, environmentName) {
+				continue
+			}
+		}
+		matches = append(matches, formatVersionSummary(&version))
+	}
+
+	output := map[string]interface{}{
+		"matches":       matches,
+		"matchCount":    len(matches),
+		"searchedCount": len(searchResult.Versions),
+		"totalCount":    searchResult.TotalCount,
+		"hasMore":       searchResult.HasNextPage,
+		"endCursor":     searchResult.EndCursor,
+	}
+	if len(matches) == 1 {
+		output["version"] = matches[0]
+	}
+	return formatResult(output)
+}
+
+func (s *Server) handleExportCycloneDXVex(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	versionID, ok := args["version_id"].(string)
+	if !ok || versionID == "" {
+		return newToolResultError("Missing required parameter: version_id"), nil
+	}
+
+	includeVulns := true
+	specVersion := stringParam(args, "spec_version")
+	if specVersion == "" {
+		specVersion = "1.6"
+	}
+	requireCompleted := []string{"VULN_SCAN"}
+	if require, ok := args["require_vuln_scan_complete"].(bool); ok && !require {
+		requireCompleted = nil
+	}
+
+	download, err := s.client.DownloadSBOM(ctx, api.DownloadSBOMInput{
+		VersionID:        versionID,
+		Spec:             "CycloneDX",
+		SpecVersion:      specVersion,
+		IncludeVulns:     &includeVulns,
+		RequireCompleted: requireCompleted,
+	})
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to export CycloneDX VEX: %v", err)), nil
+	}
+
+	includeContent := true
+	if val, ok := args["include_content"].(bool); ok {
+		includeContent = val
+	}
+	output := map[string]interface{}{
+		"ready":            download.Ready,
+		"filename":         download.Filename,
+		"contentType":      download.ContentType,
+		"contentLength":    len(download.Content),
+		"processingStatus": download.ProcessingStatus,
+		"spec":             "CycloneDX",
+		"specVersion":      specVersion,
+		"includeVulns":     true,
+	}
+	if includeContent {
+		output["content"] = download.Content
+	}
+	return formatResult(output)
 }
 
 func (s *Server) handleListDoctorResults(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1831,10 +1923,11 @@ func formatComponentVulns(componentVulns []api.ComponentVuln, matchReasons map[s
 	vulns := make([]map[string]interface{}, len(componentVulns))
 	for i, cv := range componentVulns {
 		vuln := map[string]interface{}{
-			"id":        cv.ID,
-			"versionId": cv.VersionID,
-			"fixedIn":   cv.FixedIn,
-			"updatedAt": cv.UpdatedAt,
+			"id":            cv.ID,
+			"versionId":     cv.VersionID,
+			"fixedIn":       cv.FixedIn,
+			"fixedVersions": cv.FixedVersions,
+			"updatedAt":     cv.UpdatedAt,
 		}
 		if includeDetail {
 			vuln["detail"] = cv.Detail
@@ -2331,6 +2424,10 @@ func sameVexName(left, right string) bool {
 	return normalizeVexName(left) == normalizeVexName(right)
 }
 
+func sameName(left, right string) bool {
+	return strings.EqualFold(strings.TrimSpace(left), strings.TrimSpace(right))
+}
+
 func normalizeVexName(name string) string {
 	name = strings.ToLower(strings.TrimSpace(name))
 	name = strings.ReplaceAll(name, "-", "_")
@@ -2764,6 +2861,69 @@ func formatComponent(component *api.VersionComponent) map[string]interface{} {
 		result["externalUrls"] = externalURLs
 	}
 	return result
+}
+
+func formatVersionSummary(version *api.Version) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":            version.ID,
+		"version":       version.Version,
+		"spec":          version.Spec,
+		"specVersion":   version.SpecVersion,
+		"format":        version.Format,
+		"lifecycle":     version.Lifecycle,
+		"environmentId": version.EnvironmentID,
+		"createdAt":     version.CreatedAt,
+		"updatedAt":     version.UpdatedAt,
+	}
+	if version.Stats != nil {
+		result["stats"] = map[string]interface{}{
+			"componentCount":        version.Stats.CompCount,
+			"componentWithPurl":     version.Stats.CompPurlCount,
+			"componentWithCpe":      version.Stats.CompCpeCount,
+			"componentWithLicense":  version.Stats.CompLicenseCount,
+			"componentWithSupplier": version.Stats.CompSupplierCount,
+			"vulnerabilities":       version.Stats.VulnStats,
+		}
+	}
+	if version.Environment != nil {
+		environment := map[string]interface{}{
+			"id":        version.Environment.ID,
+			"name":      version.Environment.Name,
+			"productId": version.Environment.ProductID,
+		}
+		if version.Environment.Product != nil {
+			environment["product"] = map[string]interface{}{
+				"id":   version.Environment.Product.ID,
+				"name": version.Environment.Product.Name,
+			}
+		}
+		result["environment"] = environment
+	}
+	return result
+}
+
+func formatComponentVulnerabilitySummaries(result *api.ComponentsResult) map[string]interface{} {
+	summaries := make([]map[string]interface{}, 0, len(result.Components))
+	for _, component := range result.Components {
+		if component.VulnSummary == nil {
+			continue
+		}
+		summaries = append(summaries, map[string]interface{}{
+			"componentId":      component.ID,
+			"componentName":    component.Name,
+			"componentVersion": component.Version,
+			"purl":             component.Purl,
+			"totalCount":       component.VulnSummary.TotalCount,
+			"severityCounts":   component.VulnSummary.Stats,
+		})
+	}
+	return map[string]interface{}{
+		"components":   summaries,
+		"totalCount":   result.TotalCount,
+		"hasMore":      result.HasNextPage,
+		"endCursor":    result.EndCursor,
+		"scannedCount": len(result.Components),
+	}
 }
 
 func formatComponentVuln(componentVuln *api.ComponentVuln) map[string]interface{} {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -29,6 +29,9 @@ type fakeLynkClient struct {
 	listProductsInput           api.ListProductsInput
 	listVersionVulnsInput       api.ListVersionVulnsInput
 	listComponentVulnsInput     api.ListComponentVulnsInput
+	searchVersionsInput         api.VersionSearchInput
+	listComponentsInput         api.ListComponentsInput
+	downloadSBOMInput           api.DownloadSBOMInput
 	bulkUpdateComponentVexInput api.BulkUpdateComponentVexInput
 	ticketingStatusInput        api.TicketingStatusInput
 }
@@ -123,6 +126,102 @@ func (f *fakeLynkClient) GetEnvironment(ctx context.Context, id string) (*api.En
 	}, nil
 }
 
+func (f *fakeLynkClient) GetVersion(ctx context.Context, id string) (*api.Version, error) {
+	return &api.Version{
+		ID:            id,
+		Version:       "1.0.0",
+		Spec:          "CycloneDX",
+		SpecVersion:   "1.6",
+		Format:        "json",
+		Lifecycle:     "released",
+		EnvironmentID: "env-1",
+		Stats: &api.VersionStats{
+			CompCount: 2,
+			VulnStats: map[string]interface{}{
+				"critical": 1,
+			},
+		},
+		Environment: &api.Environment{
+			ID:        "env-1",
+			Name:      "production",
+			ProductID: "product-1",
+		},
+	}, nil
+}
+
+func (f *fakeLynkClient) SearchVersions(ctx context.Context, input api.VersionSearchInput) (*api.VersionsResult, error) {
+	f.searchVersionsInput = input
+	return &api.VersionsResult{
+		Versions: []api.Version{
+			{
+				ID:            "version-1",
+				Version:       "1.0.0",
+				Spec:          "CycloneDX",
+				SpecVersion:   "1.6",
+				Format:        "json",
+				Lifecycle:     "released",
+				EnvironmentID: "env-1",
+				Environment: &api.Environment{
+					ID:        "env-1",
+					Name:      "production",
+					ProductID: "product-1",
+					Product: &api.Product{
+						ID:   "product-1",
+						Name: "Product 1",
+					},
+				},
+			},
+			{
+				ID:            "version-2",
+				Version:       "1.0.1",
+				EnvironmentID: "env-2",
+				Environment: &api.Environment{
+					ID:   "env-2",
+					Name: "development",
+				},
+			},
+		},
+		TotalCount:  2,
+		HasNextPage: true,
+		EndCursor:   "version-cursor-2",
+	}, nil
+}
+
+func (f *fakeLynkClient) ListComponents(ctx context.Context, input api.ListComponentsInput) (*api.ComponentsResult, error) {
+	f.listComponentsInput = input
+	return &api.ComponentsResult{
+		Components: []api.VersionComponent{
+			{
+				ID:      "component-1",
+				Name:    "openssl",
+				Version: "3.0.0",
+				Purl:    "pkg:generic/openssl@3.0.0",
+				VulnSummary: &api.ComponentVulnerabilitySummary{
+					TotalCount: 2,
+					Stats: map[string]interface{}{
+						"high": 2,
+					},
+				},
+			},
+		},
+		TotalCount:  1,
+		HasNextPage: false,
+	}, nil
+}
+
+func (f *fakeLynkClient) DownloadSBOM(ctx context.Context, input api.DownloadSBOMInput) (*api.DownloadSBOMResult, error) {
+	f.downloadSBOMInput = input
+	return &api.DownloadSBOMResult{
+		Ready:       true,
+		Filename:    "bom.cdx.json",
+		ContentType: "application/json",
+		Content:     `{"bomFormat":"CycloneDX"}`,
+		ProcessingStatus: map[string]string{
+			"vulnScan": "FINISHED",
+		},
+	}, nil
+}
+
 func (f *fakeLynkClient) ListVersionVulns(ctx context.Context, input api.ListVersionVulnsInput) (*api.ComponentVulnsResult, error) {
 	f.listVersionVulnsInput = input
 	return &api.ComponentVulnsResult{
@@ -131,6 +230,9 @@ func (f *fakeLynkClient) ListVersionVulns(ctx context.Context, input api.ListVer
 				ID:          "component-vuln-1",
 				ComponentID: "component-1",
 				VersionID:   input.VersionID,
+				FixedVersions: []string{
+					"3.0.1",
+				},
 				Component: &api.VersionComponent{
 					ID:        "component-1",
 					Name:      "openssl",
@@ -382,6 +484,115 @@ func TestHandleListVulnerabilities_PassesAfterAndReturnsEndCursor(t *testing.T) 
 	}
 }
 
+func TestHandleGetVersion_IncludesComponentVulnerabilitySummary(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleGetVersion(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"id":                             "version-1",
+				"include_component_vuln_summary": true,
+				"component_summary_limit":        25,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleGetVersion returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleGetVersion returned tool error: %#v", result.Content)
+	}
+	if client.listComponentsInput.VersionID != "version-1" || client.listComponentsInput.First != 25 {
+		t.Fatalf("unexpected ListComponents input: %#v", client.listComponentsInput)
+	}
+
+	output := toolResultMap(t, result)
+	summary := output["componentVulnerabilitySummary"].(map[string]interface{})
+	components := summary["components"].([]interface{})
+	if len(components) != 1 {
+		t.Fatalf("len(summary components) = %d, want 1", len(components))
+	}
+	component := components[0].(map[string]interface{})
+	if component["componentId"] != "component-1" || component["totalCount"] != float64(2) {
+		t.Fatalf("unexpected component summary: %#v", component)
+	}
+}
+
+func TestHandleFindVersion_FiltersExactProductAndEnvironment(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleFindVersion(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"version":          "1.0.0",
+				"product_name":     "product 1",
+				"environment_name": "Production",
+				"limit":            10,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleFindVersion returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleFindVersion returned tool error: %#v", result.Content)
+	}
+	if client.searchVersionsInput.Search != "1.0.0" || client.searchVersionsInput.First != 10 {
+		t.Fatalf("unexpected SearchVersions input: %#v", client.searchVersionsInput)
+	}
+
+	output := toolResultMap(t, result)
+	if output["matchCount"] != float64(1) || output["searchedCount"] != float64(2) {
+		t.Fatalf("unexpected find counts: %#v", output)
+	}
+	version := output["version"].(map[string]interface{})
+	if version["id"] != "version-1" {
+		t.Fatalf("unexpected matched version: %#v", version)
+	}
+}
+
+func TestHandleExportCycloneDXVex_PassesDownloadOptions(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleExportCycloneDXVex(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"version_id":                 "version-1",
+				"spec_version":               "1.6",
+				"include_content":            false,
+				"require_vuln_scan_complete": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleExportCycloneDXVex returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExportCycloneDXVex returned tool error: %#v", result.Content)
+	}
+	input := client.downloadSBOMInput
+	if input.VersionID != "version-1" || input.Spec != "CycloneDX" || input.SpecVersion != "1.6" {
+		t.Fatalf("unexpected DownloadSBOM input: %#v", input)
+	}
+	if input.IncludeVulns == nil || !*input.IncludeVulns {
+		t.Fatalf("IncludeVulns = %#v, want true", input.IncludeVulns)
+	}
+	if !reflect.DeepEqual(input.RequireCompleted, []string{"VULN_SCAN"}) {
+		t.Fatalf("RequireCompleted = %#v, want VULN_SCAN", input.RequireCompleted)
+	}
+
+	output := toolResultMap(t, result)
+	if output["ready"] != true || output["filename"] != "bom.cdx.json" {
+		t.Fatalf("unexpected export output: %#v", output)
+	}
+	if _, ok := output["content"]; ok {
+		t.Fatalf("content should be omitted when include_content=false: %#v", output)
+	}
+	if output["contentLength"] != float64(len(`{"bomFormat":"CycloneDX"}`)) {
+		t.Fatalf("unexpected contentLength: %#v", output["contentLength"])
+	}
+}
+
 func TestHandleListVulnerabilities_FiltersByComponentIDAndPurl(t *testing.T) {
 	client := &fakeLynkClient{}
 	server := &Server{client: client}
@@ -416,6 +627,10 @@ func TestHandleListVulnerabilities_FiltersByComponentIDAndPurl(t *testing.T) {
 	component := vulns[0].(map[string]interface{})["component"].(map[string]interface{})
 	if component["id"] != "component-1" || component["purl"] != "pkg:generic/openssl@3.0.0" {
 		t.Fatalf("unexpected component output: %#v", component)
+	}
+	fixedVersions := vulns[0].(map[string]interface{})["fixedVersions"].([]interface{})
+	if len(fixedVersions) != 1 || fixedVersions[0] != "3.0.1" {
+		t.Fatalf("unexpected fixedVersions output: %#v", fixedVersions)
 	}
 	if component["sbomId"] != "version-1" || component["versionId"] != "version-1" {
 		t.Fatalf("missing stable version identifiers: %#v", component)


### PR DESCRIPTION
## Summary
- add find_version for exact version lookup with product/environment disambiguation
- add optional per-component vulnerability summaries to get_version
- add export_cyclonedx_vex for CycloneDX exports with vulnerabilities
- return fixedVersions alongside fixedIn and mark Phase 6 complete in docs/customer-mcp-gaps.md

## Validation
- GOCACHE=/private/tmp/lynk-mcp-go-cache go test ./...
- make build