### PR TITLE
Expose component vulnerability custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Product responses include lightweight repository import metadata when available.
 
 Vulnerability responses include both `fixedIn` and `fixedVersions`; prefer `fixedVersions` when present because it is structured.
 
+Vulnerability responses include `customFieldAttributes` when component vulnerability custom fields are present. Each attribute includes its value, field definition ID, and definition metadata such as `displayName`, `internalName`, and `fieldType`.
+
 ### VEX
 
 | Tool | Description |
@@ -390,6 +392,8 @@ Vulnerability responses include both `fixedIn` and `fixedVersions`; prefer `fixe
 | `list_vex_justifications` | List VEX justifications with UUIDs for CVE triage |
 | `update_component_vex` | Update VEX data for a component vulnerability; requires `confirm=true` |
 | `bulk_update_component_vex` | Update VEX data for multiple component vulnerabilities with one shared payload; requires `confirm=true` |
+
+Use `component_vuln_custom_field_attributes` on `update_component_vex` or `bulk_update_component_vex` to update custom VEX fields. Pass `componentVulnCustomFieldDefinitionId` and `value` to set a field, include `id` when updating an existing attribute, or pass `_destroy: true` with `id` to remove one.
 
 ### Supply-Chain Security Incidents
 

--- a/internal/api/vulnerabilities.go
+++ b/internal/api/vulnerabilities.go
@@ -65,6 +65,7 @@ type ComponentVuln struct {
 	Vuln             *Vuln
 	VexStatus        *VexStatus
 	VexJustification *VexJustification
+	CustomFields     []ComponentVulnCustomField
 }
 
 // VexStatus represents a VEX status
@@ -77,6 +78,48 @@ type VexStatus struct {
 type VexJustification struct {
 	ID   string
 	Name string
+}
+
+// ComponentVulnCustomField represents a custom field value attached to a component vulnerability.
+type ComponentVulnCustomField struct {
+	ID                                   string
+	ComponentVulnCustomFieldDefinitionID string
+	Value                                string
+	VexableID                            string
+	VexableType                          string
+	CreatedAt                            time.Time
+	UpdatedAt                            time.Time
+	ComponentVulnCustomFieldDefinition   *ComponentVulnCustomFieldDefinition
+}
+
+// ComponentVulnCustomFieldDefinition describes a custom field available for component vulnerabilities.
+type ComponentVulnCustomFieldDefinition struct {
+	ID             string
+	DisplayName    string
+	FieldType      string
+	InternalName   string
+	MinValue       *int
+	MaxValue       *int
+	OrganizationID string
+}
+
+type graphQLComponentVulnCustomField struct {
+	ID                                   string    `json:"id"`
+	ComponentVulnCustomFieldDefinitionID string    `json:"componentVulnCustomFieldDefinitionId"`
+	Value                                string    `json:"value"`
+	VexableID                            string    `json:"vexableId"`
+	VexableType                          string    `json:"vexableType"`
+	CreatedAt                            time.Time `json:"createdAt"`
+	UpdatedAt                            time.Time `json:"updatedAt"`
+	ComponentVulnCustomFieldDefinition   *struct {
+		ID             string `json:"id"`
+		DisplayName    string `json:"displayName"`
+		FieldType      string `json:"fieldType"`
+		InternalName   string `json:"internalName"`
+		MinValue       *int   `json:"minValue"`
+		MaxValue       *int   `json:"maxValue"`
+		OrganizationID string `json:"organizationId"`
+	} `json:"componentVulnCustomFieldDefinition"`
 }
 
 // ComponentVulnsResult represents the result of listing component vulnerabilities
@@ -177,6 +220,7 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 						ID   string `json:"id"`
 						Name string `json:"name"`
 					} `json:"vexJustification"`
+					ComponentVulnCustomFields []graphQLComponentVulnCustomField `json:"componentVulnCustomFields"`
 				} `json:"nodes"`
 				TotalCount int `json:"totalCount"`
 				PageInfo   struct {
@@ -205,6 +249,7 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 			ActionStmt:    n.ActionStmt,
 			CreatedAt:     n.CreatedAt,
 			UpdatedAt:     n.UpdatedAt,
+			CustomFields:  mapComponentVulnCustomFields(n.ComponentVulnCustomFields),
 		}
 		if n.Component != nil {
 			cv.Component = &VersionComponent{
@@ -465,6 +510,7 @@ func (c *Client) ListComponentVulns(ctx context.Context, input ListComponentVuln
 					ID   string `json:"id"`
 					Name string `json:"name"`
 				} `json:"vexStatus"`
+				ComponentVulnCustomFields []graphQLComponentVulnCustomField `json:"componentVulnCustomFields"`
 			} `json:"nodes"`
 			TotalCount int `json:"totalCount"`
 			PageInfo   struct {
@@ -489,6 +535,7 @@ func (c *Client) ListComponentVulns(ctx context.Context, input ListComponentVuln
 			FixedVersions: n.FixedVersions,
 			CreatedAt:     n.CreatedAt,
 			UpdatedAt:     n.UpdatedAt,
+			CustomFields:  mapComponentVulnCustomFields(n.ComponentVulnCustomFields),
 		}
 		if n.Component != nil {
 			cv.Component = &VersionComponent{
@@ -531,6 +578,36 @@ func (c *Client) ListComponentVulns(ctx context.Context, input ListComponentVuln
 		HasNextPage:    result.ComponentVulns.PageInfo.HasNextPage,
 		EndCursor:      result.ComponentVulns.PageInfo.EndCursor,
 	}, nil
+}
+
+func mapComponentVulnCustomFields(fields []graphQLComponentVulnCustomField) []ComponentVulnCustomField {
+	if len(fields) == 0 {
+		return nil
+	}
+	result := make([]ComponentVulnCustomField, len(fields))
+	for i, field := range fields {
+		result[i] = ComponentVulnCustomField{
+			ID:                                   field.ID,
+			ComponentVulnCustomFieldDefinitionID: field.ComponentVulnCustomFieldDefinitionID,
+			Value:                                field.Value,
+			VexableID:                            field.VexableID,
+			VexableType:                          field.VexableType,
+			CreatedAt:                            field.CreatedAt,
+			UpdatedAt:                            field.UpdatedAt,
+		}
+		if field.ComponentVulnCustomFieldDefinition != nil {
+			result[i].ComponentVulnCustomFieldDefinition = &ComponentVulnCustomFieldDefinition{
+				ID:             field.ComponentVulnCustomFieldDefinition.ID,
+				DisplayName:    field.ComponentVulnCustomFieldDefinition.DisplayName,
+				FieldType:      field.ComponentVulnCustomFieldDefinition.FieldType,
+				InternalName:   field.ComponentVulnCustomFieldDefinition.InternalName,
+				MinValue:       field.ComponentVulnCustomFieldDefinition.MinValue,
+				MaxValue:       field.ComponentVulnCustomFieldDefinition.MaxValue,
+				OrganizationID: field.ComponentVulnCustomFieldDefinition.OrganizationID,
+			}
+		}
+	}
+	return result
 }
 
 func addEpssRangeVar(vars map[string]interface{}, min, max *float64) {

--- a/internal/api/vulnerabilities_test.go
+++ b/internal/api/vulnerabilities_test.go
@@ -123,6 +123,91 @@ func TestListVersionVulns_AcceptsNestedVulnTimestampsWithoutTimezone(t *testing.
 	}
 }
 
+func TestListVersionVulns_MapsCustomFieldAttributes(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"sbom": {
+					"vulns": {
+						"nodes": [
+							{
+								"id": "component-vuln-1",
+								"componentId": "component-1",
+								"vulnId": "vuln-1",
+								"sbomId": "version-1",
+								"fixedIn": "",
+								"fixedVersions": [],
+								"detail": "",
+								"impact": "",
+								"actionStmt": "",
+								"createdAt": "2026-04-16T23:00:09Z",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"component": null,
+								"vuln": null,
+								"vexStatus": null,
+								"vexJustification": null,
+								"componentVulnCustomFields": [
+									{
+										"id": "custom-field-1",
+										"componentVulnCustomFieldDefinitionId": "field-def-1",
+										"value": "12",
+										"vexableId": "component-vuln-1",
+										"vexableType": "ComponentVuln",
+										"createdAt": "2026-04-17T00:00:00Z",
+										"updatedAt": "2026-04-18T00:00:00Z",
+										"componentVulnCustomFieldDefinition": {
+											"id": "field-def-1",
+											"displayName": "CRM age",
+											"fieldType": "RANGE",
+											"internalName": "crm_age",
+											"minValue": 0,
+											"maxValue": 14,
+											"organizationId": "org-1"
+										}
+									}
+								]
+							}
+						],
+						"totalCount": 1,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListVersionVulns(context.Background(), ListVersionVulnsInput{VersionID: "version-1"})
+	if err != nil {
+		t.Fatalf("ListVersionVulns returned error: %v", err)
+	}
+
+	if len(result.ComponentVulns) != 1 {
+		t.Fatalf("len(ComponentVulns) = %d, want 1", len(result.ComponentVulns))
+	}
+	customFields := result.ComponentVulns[0].CustomFields
+	if len(customFields) != 1 {
+		t.Fatalf("len(CustomFields) = %d, want 1", len(customFields))
+	}
+	field := customFields[0]
+	if field.ID != "custom-field-1" || field.ComponentVulnCustomFieldDefinitionID != "field-def-1" || field.Value != "12" {
+		t.Fatalf("unexpected custom field: %#v", field)
+	}
+	if field.ComponentVulnCustomFieldDefinition == nil {
+		t.Fatal("expected custom field definition")
+	}
+	definition := field.ComponentVulnCustomFieldDefinition
+	if definition.DisplayName != "CRM age" || definition.FieldType != "RANGE" || definition.InternalName != "crm_age" {
+		t.Fatalf("unexpected custom field definition: %#v", definition)
+	}
+	if definition.MaxValue == nil || *definition.MaxValue != 14 {
+		t.Fatalf("MaxValue = %#v, want 14", definition.MaxValue)
+	}
+}
+
 func TestListComponentVulns_PassesComponentIDs(t *testing.T) {
 	gql := &fakeGraphQLExecutor{
 		pages: []string{
@@ -244,6 +329,74 @@ func TestListComponentVulns_SendsMetadataAndScopeFilters(t *testing.T) {
 	}
 	if got := gql.requests[0]["projectIds"]; !stringSlicesEqual(got, []string{"environment-1"}) {
 		t.Fatalf("projectIds = %#v, want environment-1", got)
+	}
+}
+
+func TestListComponentVulns_MapsCustomFieldAttributes(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentVulns": {
+					"nodes": [
+						{
+							"id": "component-vuln-1",
+							"componentId": "component-1",
+							"vulnId": "vuln-1",
+							"sbomId": "version-1",
+							"fixedIn": "",
+							"fixedVersions": [],
+							"createdAt": "2026-04-16T23:00:09Z",
+							"updatedAt": "2026-04-16T23:00:09Z",
+							"component": null,
+							"vuln": null,
+							"vexStatus": null,
+							"componentVulnCustomFields": [
+								{
+									"id": "custom-field-1",
+									"componentVulnCustomFieldDefinitionId": "field-def-1",
+									"value": "7",
+									"vexableId": "component-vuln-1",
+									"vexableType": "ComponentVuln",
+									"createdAt": "2026-04-17T00:00:00Z",
+									"updatedAt": "2026-04-18T00:00:00Z",
+									"componentVulnCustomFieldDefinition": {
+										"id": "field-def-1",
+										"displayName": "CRM age",
+										"fieldType": "RANGE",
+										"internalName": "crm_age",
+										"minValue": 0,
+										"maxValue": 14,
+										"organizationId": "org-1"
+									}
+								}
+							]
+						}
+					],
+					"totalCount": 1,
+					"pageInfo": {
+						"hasNextPage": false,
+						"endCursor": ""
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListComponentVulns(context.Background(), ListComponentVulnsInput{})
+	if err != nil {
+		t.Fatalf("ListComponentVulns returned error: %v", err)
+	}
+
+	if len(result.ComponentVulns) != 1 {
+		t.Fatalf("len(ComponentVulns) = %d, want 1", len(result.ComponentVulns))
+	}
+	customFields := result.ComponentVulns[0].CustomFields
+	if len(customFields) != 1 {
+		t.Fatalf("len(CustomFields) = %d, want 1", len(customFields))
+	}
+	if customFields[0].Value != "7" || customFields[0].ComponentVulnCustomFieldDefinition == nil {
+		t.Fatalf("unexpected custom field: %#v", customFields[0])
 	}
 }
 

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -601,6 +601,24 @@ const (
 							id
 							name
 						}
+						componentVulnCustomFields {
+							id
+							componentVulnCustomFieldDefinitionId
+							value
+							vexableId
+							vexableType
+							createdAt
+							updatedAt
+							componentVulnCustomFieldDefinition {
+								id
+								displayName
+								fieldType
+								internalName
+								minValue
+								maxValue
+								organizationId
+							}
+						}
 					}
 					totalCount
 					pageInfo {
@@ -694,6 +712,24 @@ const (
 					vexStatus {
 						id
 						name
+					}
+					componentVulnCustomFields {
+						id
+						componentVulnCustomFieldDefinitionId
+						value
+						vexableId
+						vexableType
+						createdAt
+						updatedAt
+						componentVulnCustomFieldDefinition {
+							id
+							displayName
+							fieldType
+							internalName
+							minValue
+							maxValue
+							organizationId
+						}
 					}
 				}
 				totalCount

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2203,6 +2203,9 @@ func formatComponentVulns(componentVulns []api.ComponentVuln, matchReasons map[s
 			vuln["vexJustification"] = cv.VexJustification.Name
 			vuln["vexJustificationId"] = cv.VexJustification.ID
 		}
+		if len(cv.CustomFields) > 0 {
+			vuln["customFieldAttributes"] = formatComponentVulnCustomFields(cv.CustomFields)
+		}
 		vulns[i] = vuln
 	}
 	return vulns
@@ -3179,7 +3182,46 @@ func formatComponentVuln(componentVuln *api.ComponentVuln) map[string]interface{
 			"name": componentVuln.VexJustification.Name,
 		}
 	}
+	if len(componentVuln.CustomFields) > 0 {
+		result["customFieldAttributes"] = formatComponentVulnCustomFields(componentVuln.CustomFields)
+	}
 	return result
+}
+
+func formatComponentVulnCustomFields(customFields []api.ComponentVulnCustomField) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(customFields))
+	for i, customField := range customFields {
+		item := map[string]interface{}{
+			"id":                                   customField.ID,
+			"componentVulnCustomFieldDefinitionId": customField.ComponentVulnCustomFieldDefinitionID,
+			"value":                                customField.Value,
+			"vexableId":                            customField.VexableID,
+			"vexableType":                          customField.VexableType,
+			"createdAt":                            customField.CreatedAt,
+			"updatedAt":                            customField.UpdatedAt,
+		}
+		if customField.ComponentVulnCustomFieldDefinition != nil {
+			definition := customField.ComponentVulnCustomFieldDefinition
+			item["definition"] = map[string]interface{}{
+				"id":             definition.ID,
+				"displayName":    definition.DisplayName,
+				"fieldType":      definition.FieldType,
+				"internalName":   definition.InternalName,
+				"minValue":       intPointerValue(definition.MinValue),
+				"maxValue":       intPointerValue(definition.MaxValue),
+				"organizationId": definition.OrganizationID,
+			}
+		}
+		result[i] = item
+	}
+	return result
+}
+
+func intPointerValue(value *int) interface{} {
+	if value == nil {
+		return nil
+	}
+	return *value
 }
 
 func formatBulkComponentVexResult(requestedIDs []string, result *api.BulkUpdateComponentVexResult) map[string]interface{} {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1114,6 +1114,49 @@ func TestComponentVulnMatchReasons_ReportsMatchingExceptionalMetadata(t *testing
 	}
 }
 
+func TestFormatComponentVulns_IncludesCustomFieldAttributes(t *testing.T) {
+	maxValue := 14
+	vulns := []api.ComponentVuln{
+		{
+			ID:        "component-vuln-1",
+			VersionID: "version-1",
+			CustomFields: []api.ComponentVulnCustomField{
+				{
+					ID:                                   "custom-field-1",
+					ComponentVulnCustomFieldDefinitionID: "field-def-1",
+					Value:                                "12",
+					VexableID:                            "component-vuln-1",
+					VexableType:                          "ComponentVuln",
+					ComponentVulnCustomFieldDefinition: &api.ComponentVulnCustomFieldDefinition{
+						ID:           "field-def-1",
+						DisplayName:  "CRM age",
+						FieldType:    "RANGE",
+						InternalName: "crm_age",
+						MaxValue:     &maxValue,
+					},
+				},
+			},
+		},
+	}
+
+	formatted := formatComponentVulns(vulns, nil, false)
+	customFields, ok := formatted[0]["customFieldAttributes"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("customFieldAttributes = %T %#v, want []map[string]interface{}", formatted[0]["customFieldAttributes"], formatted[0]["customFieldAttributes"])
+	}
+	if len(customFields) != 1 {
+		t.Fatalf("len(customFieldAttributes) = %d, want 1", len(customFields))
+	}
+	field := customFields[0]
+	if field["componentVulnCustomFieldDefinitionId"] != "field-def-1" || field["value"] != "12" {
+		t.Fatalf("unexpected custom field output: %#v", field)
+	}
+	definition := field["definition"].(map[string]interface{})
+	if definition["displayName"] != "CRM age" || definition["maxValue"] != 14 {
+		t.Fatalf("unexpected definition output: %#v", definition)
+	}
+}
+
 func TestFilterComponentVulnsByCvss_AppliesThresholds(t *testing.T) {
 	cvssMin := 9.0
 	filters := vulnerabilityMetadataFilters{CvssMin: &cvssMin}


### PR DESCRIPTION
## Summary
- Fetch component vulnerability custom fields in version-scoped and org-wide vulnerability queries
- Map custom field attributes and definition metadata through the API layer
- Return customFieldAttributes from vulnerability and VEX update MCP responses
- Document read/write custom-field behavior in the README

