### PR TITLE
Support labels for product filtering

### DIFF
--- a/internal/api/products.go
+++ b/internal/api/products.go
@@ -34,9 +34,20 @@ type Product struct {
 	OrganizationID           string
 	UpdatedAt                time.Time
 	VersionsCount            int
+	Labels                   []Label
 	Repository               *ImportedRepository
 	TicketingDefaultsSummary *TicketingDefaultsSummary
 	Environments             []Environment
+}
+
+// Label represents an organization label applied to products.
+type Label struct {
+	ID             string
+	Name           string
+	Color          string
+	OrganizationID string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // Environment represents an environment (formerly project)
@@ -80,11 +91,65 @@ type ProductsResult struct {
 	EndCursor   string
 }
 
+// LabelsResult represents the result of listing labels.
+type LabelsResult struct {
+	Labels      []Label
+	TotalCount  int
+	HasNextPage bool
+	EndCursor   string
+}
+
 // ListProductsInput contains parameters for listing products
 type ListProductsInput struct {
+	First    int
+	After    string
+	Search   string
+	LabelIDs []string
+}
+
+// ListLabelsInput contains parameters for listing labels.
+type ListLabelsInput struct {
 	First  int
 	After  string
 	Search string
+}
+
+// ListLabels fetches labels with pagination.
+func (c *Client) ListLabels(ctx context.Context, input ListLabelsInput) (*LabelsResult, error) {
+	vars := make(map[string]interface{})
+	if input.First > 0 {
+		vars["first"] = input.First
+	} else {
+		vars["first"] = 50
+	}
+	if input.After != "" {
+		vars["after"] = input.After
+	}
+	if input.Search != "" {
+		vars["search"] = input.Search
+	}
+
+	var result struct {
+		Labels struct {
+			Nodes      []labelNode `json:"nodes"`
+			TotalCount int         `json:"totalCount"`
+			PageInfo   struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"labels"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.LabelsQuery, vars, &result); err != nil {
+		return nil, err
+	}
+
+	return &LabelsResult{
+		Labels:      mapLabelNodes(result.Labels.Nodes),
+		TotalCount:  result.Labels.TotalCount,
+		HasNextPage: result.Labels.PageInfo.HasNextPage,
+		EndCursor:   result.Labels.PageInfo.EndCursor,
+	}, nil
 }
 
 // ListProducts fetches products with pagination
@@ -101,6 +166,9 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 	if input.Search != "" {
 		vars["search"] = input.Search
 	}
+	if len(input.LabelIDs) > 0 {
+		vars["labelIds"] = input.LabelIDs
+	}
 
 	var result struct {
 		Organization struct {
@@ -113,6 +181,7 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 					OrganizationID     string                 `json:"organizationId"`
 					UpdatedAt          time.Time              `json:"updatedAt"`
 					SbomsCount         int                    `json:"sbomsCount"`
+					Labels             []labelNode            `json:"labels"`
 					ImportedRepository *productRepositoryNode `json:"importedRepository"`
 					Projects           struct {
 						Nodes []struct {
@@ -143,6 +212,7 @@ func (c *Client) ListProducts(ctx context.Context, input ListProductsInput) (*Pr
 			OrganizationID:           n.OrganizationID,
 			UpdatedAt:                n.UpdatedAt,
 			VersionsCount:            n.SbomsCount,
+			Labels:                   mapLabelNodes(n.Labels),
 			Repository:               mapProductRepository(n.ImportedRepository),
 			TicketingDefaultsSummary: summarizeTicketingDefaults(n.Projects.Nodes),
 		}
@@ -180,6 +250,7 @@ func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
 				OrganizationID     string                 `json:"organizationId"`
 				UpdatedAt          time.Time              `json:"updatedAt"`
 				SbomsCount         int                    `json:"sbomsCount"`
+				Labels             []labelNode            `json:"labels"`
 				ImportedRepository *productRepositoryNode `json:"importedRepository"`
 				Projects           struct {
 					Nodes []struct {
@@ -212,6 +283,7 @@ func (c *Client) GetProduct(ctx context.Context, id string) (*Product, error) {
 				OrganizationID: result.ProjectGroup.OrganizationID,
 				UpdatedAt:      result.ProjectGroup.UpdatedAt,
 				VersionsCount:  result.ProjectGroup.SbomsCount,
+				Labels:         mapLabelNodes(result.ProjectGroup.Labels),
 				Repository:     mapProductRepository(result.ProjectGroup.ImportedRepository),
 			}
 		}
@@ -315,6 +387,15 @@ type productRepositoryNode struct {
 	WebhookEnabled bool   `json:"webhookEnabled"`
 }
 
+type labelNode struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Color          string    `json:"color"`
+	OrganizationID string    `json:"organizationId"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
 type productIssueTrackerSettingNode struct {
 	ID             string      `json:"id"`
 	Provider       string      `json:"provider"`
@@ -326,6 +407,24 @@ type productIssueTrackerSettingNode struct {
 	Components     interface{} `json:"components"`
 	EnableJiraSync bool        `json:"enableJiraSync"`
 	UpdatedAt      time.Time   `json:"updatedAt"`
+}
+
+func mapLabelNodes(nodes []labelNode) []Label {
+	if len(nodes) == 0 {
+		return nil
+	}
+	labels := make([]Label, len(nodes))
+	for i, node := range nodes {
+		labels[i] = Label{
+			ID:             node.ID,
+			Name:           node.Name,
+			Color:          node.Color,
+			OrganizationID: node.OrganizationID,
+			CreatedAt:      node.CreatedAt,
+			UpdatedAt:      node.UpdatedAt,
+		}
+	}
+	return labels
 }
 
 func mapProductRepository(node *productRepositoryNode) *ImportedRepository {

--- a/internal/api/products_test.go
+++ b/internal/api/products_test.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -164,6 +165,111 @@ func TestListProducts_MapsImportedRepositoryTypesAndTicketingSummary(t *testing.
 		if summary.JiraProjectKeys[i] != wantKeys[i] {
 			t.Fatalf("JiraProjectKeys = %#v, want %#v", summary.JiraProjectKeys, wantKeys)
 		}
+	}
+}
+
+func TestListLabels_MapsInputsAndResults(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"labels": {
+					"nodes": [
+						{
+							"id": "label-1",
+							"name": "Aidash",
+							"color": "#0052cc",
+							"organizationId": "org-1",
+							"createdAt": "2026-01-01T00:00:00Z",
+							"updatedAt": "2026-01-02T00:00:00Z"
+						}
+					],
+					"totalCount": 2,
+					"pageInfo": {
+						"hasNextPage": true,
+						"endCursor": "label-cursor-2"
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListLabels(context.Background(), ListLabelsInput{
+		First:  10,
+		After:  "label-cursor-1",
+		Search: "Aidash",
+	})
+	if err != nil {
+		t.Fatalf("ListLabels returned error: %v", err)
+	}
+	if gql.requests[0]["first"] != 10 || gql.requests[0]["after"] != "label-cursor-1" || gql.requests[0]["search"] != "Aidash" {
+		t.Fatalf("unexpected request variables: %#v", gql.requests[0])
+	}
+	if result.TotalCount != 2 || !result.HasNextPage || result.EndCursor != "label-cursor-2" {
+		t.Fatalf("unexpected pagination result: %#v", result)
+	}
+	if len(result.Labels) != 1 || result.Labels[0].ID != "label-1" || result.Labels[0].Name != "Aidash" || result.Labels[0].Color != "#0052cc" {
+		t.Fatalf("unexpected labels: %#v", result.Labels)
+	}
+}
+
+func TestListProducts_SendsLabelIDsAndMapsLabels(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"organization": {
+					"projectGroups": {
+						"nodes": [
+							{
+								"id": "product-1",
+								"name": "Product 1",
+								"description": "",
+								"enabled": true,
+								"organizationId": "org-1",
+								"updatedAt": "2026-04-16T23:00:09Z",
+								"sbomsCount": 1,
+								"labels": [
+									{
+										"id": "label-1",
+										"name": "Aidash",
+										"color": "#0052cc",
+										"organizationId": "org-1",
+										"createdAt": "2026-01-01T00:00:00Z",
+										"updatedAt": "2026-01-02T00:00:00Z"
+									}
+								],
+								"importedRepository": null,
+								"projects": {"nodes": []}
+							}
+						],
+						"totalCount": 1,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListProducts(context.Background(), ListProductsInput{
+		First:    20,
+		LabelIDs: []string{"label-1", "label-2"},
+	})
+	if err != nil {
+		t.Fatalf("ListProducts returned error: %v", err)
+	}
+	if !reflect.DeepEqual(gql.requests[0]["labelIds"], []string{"label-1", "label-2"}) {
+		t.Fatalf("labelIds = %#v, want label-1,label-2", gql.requests[0]["labelIds"])
+	}
+	if len(result.Products) != 1 || len(result.Products[0].Labels) != 1 {
+		t.Fatalf("unexpected products: %#v", result.Products)
+	}
+	label := result.Products[0].Labels[0]
+	if label.ID != "label-1" || label.Name != "Aidash" || label.Color != "#0052cc" {
+		t.Fatalf("unexpected label: %#v", label)
 	}
 }
 

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -48,11 +48,34 @@ const (
 		}
 	`
 
+	// LabelsQuery fetches labels with pagination.
+	LabelsQuery = `
+		query GetLabels($first: Int, $after: String, $search: String) {
+			labels(first: $first, after: $after, search: $search) {
+				nodes {
+					id
+					name
+					color
+					organizationId
+					createdAt
+					updatedAt
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
+					hasPreviousPage
+					startCursor
+					endCursor
+				}
+			}
+		}
+	`
+
 	// ProjectGroupsQuery fetches project groups with pagination
 	ProjectGroupsQuery = `
-		query GetProjectGroups($first: Int, $after: String, $search: String) {
+		query GetProjectGroups($first: Int, $after: String, $search: String, $labelIds: [Uuid!]) {
 			organization {
-				projectGroups(first: $first, after: $after, search: $search) {
+				projectGroups(first: $first, after: $after, search: $search, labelIds: $labelIds) {
 					nodes {
 						id
 						name
@@ -61,6 +84,14 @@ const (
 						organizationId
 						updatedAt
 						sbomsCount
+						labels {
+							id
+							name
+							color
+							organizationId
+							createdAt
+							updatedAt
+						}
 						importedRepository {
 							__typename
 							... on GithubRepository {
@@ -122,6 +153,14 @@ const (
 				organizationId
 				updatedAt
 				sbomsCount
+				labels {
+					id
+					name
+					color
+					organizationId
+					createdAt
+					updatedAt
+				}
 				importedRepository {
 					__typename
 					... on GithubRepository {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -25,6 +25,7 @@ import (
 
 type lynkClient interface {
 	GetOrganization(ctx context.Context) (*api.Organization, error)
+	ListLabels(ctx context.Context, input api.ListLabelsInput) (*api.LabelsResult, error)
 	ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error)
 	GetProduct(ctx context.Context, id string) (*api.Product, error)
 	ListVersions(ctx context.Context, input api.ListVersionsInput) (*api.VersionsResult, error)
@@ -108,10 +109,18 @@ func (s *Server) registerTools() {
 		mcp.WithDescription("Get current organization information including metrics"),
 	), s.handleGetOrganization)
 
+	s.mcp.AddTool(mcp.NewTool("list_labels",
+		mcp.WithDescription("List organization labels that can be used to filter products"),
+		mcp.WithString("search", mcp.Description("Search term to filter labels by name")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
+	), s.handleListLabels)
+
 	// Product tools
 	s.mcp.AddTool(mcp.NewTool("list_products",
 		mcp.WithDescription("List all products in the organization"),
 		mcp.WithString("search", mcp.Description("Search term to filter by name")),
+		mcp.WithArray("label_ids", mcp.Description("Filter products by one or more label UUIDs"), mcp.WithStringItems()),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 20)")),
 		mcp.WithString("after", mcp.Description("Cursor for the next page")),
 	), s.handleListProducts)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -56,10 +56,36 @@ func (s *Server) handleGetOrganization(ctx context.Context, request mcp.CallTool
 	return formatResult(result)
 }
 
+func (s *Server) handleListLabels(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	input := api.ListLabelsInput{
+		First: getIntParam(args, "limit", 50),
+	}
+	if search, ok := args["search"].(string); ok {
+		input.Search = search
+	}
+	if after, ok := args["after"].(string); ok {
+		input.After = after
+	}
+
+	result, err := s.client.ListLabels(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list labels: %v", err)), nil
+	}
+
+	return formatResult(map[string]interface{}{
+		"labels":     formatLabels(result.Labels),
+		"totalCount": result.TotalCount,
+		"hasMore":    result.HasNextPage,
+		"endCursor":  result.EndCursor,
+	})
+}
+
 func (s *Server) handleListProducts(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	input := api.ListProductsInput{
-		First: getIntParam(args, "limit", 20),
+		First:    getIntParam(args, "limit", 20),
+		LabelIDs: getStringSliceParam(args, "label_ids"),
 	}
 	if search, ok := args["search"].(string); ok {
 		input.Search = search
@@ -81,6 +107,7 @@ func (s *Server) handleListProducts(ctx context.Context, request mcp.CallToolReq
 			"description":   p.Description,
 			"enabled":       p.Enabled,
 			"versionsCount": p.VersionsCount,
+			"labels":        formatLabels(p.Labels),
 			"updatedAt":     p.UpdatedAt,
 		}
 		if p.Repository != nil {
@@ -132,6 +159,7 @@ func (s *Server) handleGetProduct(ctx context.Context, request mcp.CallToolReque
 		"description":   product.Description,
 		"enabled":       product.Enabled,
 		"versionsCount": product.VersionsCount,
+		"labels":        formatLabels(product.Labels),
 		"updatedAt":     product.UpdatedAt,
 		"environments":  environments,
 	}
@@ -2348,6 +2376,21 @@ func formatJiraDefaults(defaults *api.JiraDefaults) map[string]interface{} {
 	}
 	if defaults.Components != nil {
 		result["components"] = defaults.Components
+	}
+	return result
+}
+
+func formatLabels(labels []api.Label) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(labels))
+	for i, label := range labels {
+		result[i] = map[string]interface{}{
+			"id":             label.ID,
+			"name":           label.Name,
+			"color":          label.Color,
+			"organizationId": label.OrganizationID,
+			"createdAt":      label.CreatedAt,
+			"updatedAt":      label.UpdatedAt,
+		}
 	}
 	return result
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -27,6 +27,7 @@ import (
 
 type fakeLynkClient struct {
 	lynkClient
+	listLabelsInput             api.ListLabelsInput
 	listProductsInput           api.ListProductsInput
 	listVersionVulnsInput       api.ListVersionVulnsInput
 	listVersionVulnsInputs      []api.ListVersionVulnsInput
@@ -40,6 +41,25 @@ type fakeLynkClient struct {
 	ticketingStatusInput        api.TicketingStatusInput
 }
 
+func (f *fakeLynkClient) ListLabels(ctx context.Context, input api.ListLabelsInput) (*api.LabelsResult, error) {
+	f.listLabelsInput = input
+	return &api.LabelsResult{
+		Labels: []api.Label{
+			{
+				ID:             "label-1",
+				Name:           "Aidash",
+				Color:          "#0052cc",
+				OrganizationID: "org-1",
+				CreatedAt:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		TotalCount:  2,
+		HasNextPage: true,
+		EndCursor:   "label-cursor-2",
+	}, nil
+}
+
 func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProductsInput) (*api.ProductsResult, error) {
 	f.listProductsInput = input
 	return &api.ProductsResult{
@@ -50,6 +70,14 @@ func (f *fakeLynkClient) ListProducts(ctx context.Context, input api.ListProduct
 				Description:   "First product",
 				Enabled:       true,
 				VersionsCount: 7,
+				Labels: []api.Label{
+					{
+						ID:             "label-1",
+						Name:           "Aidash",
+						Color:          "#0052cc",
+						OrganizationID: "org-1",
+					},
+				},
 				Repository: &api.ImportedRepository{
 					Type:           "GithubRepository",
 					ID:             "repo-1",
@@ -78,6 +106,14 @@ func (f *fakeLynkClient) GetProduct(ctx context.Context, id string) (*api.Produc
 		Description:   "First product",
 		Enabled:       true,
 		VersionsCount: 7,
+		Labels: []api.Label{
+			{
+				ID:             "label-1",
+				Name:           "Aidash",
+				Color:          "#0052cc",
+				OrganizationID: "org-1",
+			},
+		},
 		Repository: &api.ImportedRepository{
 			Type:           "BitbucketRepository",
 			ID:             "repo-1",
@@ -392,6 +428,10 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 				"limit":  2,
 				"after":  "cursor-1",
 				"search": "Product",
+				"label_ids": []interface{}{
+					"label-1",
+					"label-2",
+				},
 			},
 		},
 	})
@@ -411,6 +451,9 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 	if client.listProductsInput.First != 2 {
 		t.Fatalf("First = %#v, want 2", client.listProductsInput.First)
 	}
+	if !reflect.DeepEqual(client.listProductsInput.LabelIDs, []string{"label-1", "label-2"}) {
+		t.Fatalf("LabelIDs = %#v, want label-1,label-2", client.listProductsInput.LabelIDs)
+	}
 
 	output := toolResultMap(t, result)
 	if output["endCursor"] != "cursor-2" {
@@ -421,6 +464,11 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 	}
 	products := output["products"].([]interface{})
 	product := products[0].(map[string]interface{})
+	labels := product["labels"].([]interface{})
+	label := labels[0].(map[string]interface{})
+	if label["id"] != "label-1" || label["name"] != "Aidash" {
+		t.Fatalf("unexpected labels output: %#v", labels)
+	}
 	repository := product["repository"].(map[string]interface{})
 	if repository["importStatus"] != "completed" || repository["fullName"] != "org/repo" {
 		t.Fatalf("unexpected repository output: %#v", repository)
@@ -428,6 +476,39 @@ func TestHandleListProducts_PassesAfterAndReturnsEndCursor(t *testing.T) {
 	summary := product["ticketingDefaultsSummary"].(map[string]interface{})
 	if summary["jiraConfigured"] != true {
 		t.Fatalf("unexpected ticketing summary output: %#v", summary)
+	}
+}
+
+func TestHandleListLabels_PassesFiltersAndReturnsLabels(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleListLabels(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"limit":  10,
+				"after":  "label-cursor-1",
+				"search": "Aidash",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListLabels returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListLabels returned tool error: %#v", result.Content)
+	}
+	if client.listLabelsInput.First != 10 || client.listLabelsInput.After != "label-cursor-1" || client.listLabelsInput.Search != "Aidash" {
+		t.Fatalf("unexpected ListLabels input: %#v", client.listLabelsInput)
+	}
+
+	output := toolResultMap(t, result)
+	if output["endCursor"] != "label-cursor-2" || output["hasMore"] != true {
+		t.Fatalf("unexpected pagination output: %#v", output)
+	}
+	labels := output["labels"].([]interface{})
+	label := labels[0].(map[string]interface{})
+	if label["id"] != "label-1" || label["name"] != "Aidash" || label["color"] != "#0052cc" {
+		t.Fatalf("unexpected labels output: %#v", labels)
 	}
 }
 
@@ -445,6 +526,11 @@ func TestHandleGetProduct_ReturnsRepositoryAndJiraDefaults(t *testing.T) {
 	repository := output["repository"].(map[string]interface{})
 	if repository["type"] != "BitbucketRepository" || repository["importStatus"] != "completed" {
 		t.Fatalf("unexpected repository output: %#v", repository)
+	}
+	labels := output["labels"].([]interface{})
+	label := labels[0].(map[string]interface{})
+	if label["id"] != "label-1" || label["name"] != "Aidash" {
+		t.Fatalf("unexpected labels output: %#v", labels)
 	}
 	environments := output["environments"].([]interface{})
 	env := environments[0].(map[string]interface{})


### PR DESCRIPTION
## Summary
- add a list_labels MCP tool backed by the API labels query
- include labels in list_products and get_product responses
- add label_ids filtering to list_products

## Validation
- go test ./internal/api ./internal/mcp
- go test ./...
- built branch binary at /tmp/lynk-mcp-labels
- live MCP stdio check against local Aidash API: list_labels returned labels, and list_products filtered by the Approved label returned two labeled products