### PR TITLE
Add custom vuln field definition lookup tool

### DIFF
--- a/internal/api/vulnerabilities.go
+++ b/internal/api/vulnerabilities.go
@@ -101,6 +101,16 @@ type ComponentVulnCustomFieldDefinition struct {
 	MinValue       *int
 	MaxValue       *int
 	OrganizationID string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// ComponentVulnCustomFieldDefinitionsResult represents custom field definitions with pagination.
+type ComponentVulnCustomFieldDefinitionsResult struct {
+	Definitions []ComponentVulnCustomFieldDefinition
+	TotalCount  int
+	HasNextPage bool
+	EndCursor   string
 }
 
 type graphQLComponentVulnCustomField struct {
@@ -112,13 +122,15 @@ type graphQLComponentVulnCustomField struct {
 	CreatedAt                            time.Time `json:"createdAt"`
 	UpdatedAt                            time.Time `json:"updatedAt"`
 	ComponentVulnCustomFieldDefinition   *struct {
-		ID             string `json:"id"`
-		DisplayName    string `json:"displayName"`
-		FieldType      string `json:"fieldType"`
-		InternalName   string `json:"internalName"`
-		MinValue       *int   `json:"minValue"`
-		MaxValue       *int   `json:"maxValue"`
-		OrganizationID string `json:"organizationId"`
+		ID             string    `json:"id"`
+		DisplayName    string    `json:"displayName"`
+		FieldType      string    `json:"fieldType"`
+		InternalName   string    `json:"internalName"`
+		MinValue       *int      `json:"minValue"`
+		MaxValue       *int      `json:"maxValue"`
+		OrganizationID string    `json:"organizationId"`
+		CreatedAt      time.Time `json:"createdAt"`
+		UpdatedAt      time.Time `json:"updatedAt"`
 	} `json:"componentVulnCustomFieldDefinition"`
 }
 
@@ -128,6 +140,12 @@ type ComponentVulnsResult struct {
 	TotalCount     int
 	HasNextPage    bool
 	EndCursor      string
+}
+
+// ListComponentVulnCustomFieldDefinitionsInput contains parameters for listing custom field definitions.
+type ListComponentVulnCustomFieldDefinitionsInput struct {
+	First int
+	After string
 }
 
 // ListVersionVulnsInput contains parameters for listing version vulnerabilities
@@ -302,6 +320,66 @@ func (c *Client) ListVersionVulns(ctx context.Context, input ListVersionVulnsInp
 		TotalCount:     result.Sbom.Vulns.TotalCount,
 		HasNextPage:    result.Sbom.Vulns.PageInfo.HasNextPage,
 		EndCursor:      result.Sbom.Vulns.PageInfo.EndCursor,
+	}, nil
+}
+
+// ListComponentVulnCustomFieldDefinitions fetches custom field definitions for component vulnerabilities.
+func (c *Client) ListComponentVulnCustomFieldDefinitions(ctx context.Context, input ListComponentVulnCustomFieldDefinitionsInput) (*ComponentVulnCustomFieldDefinitionsResult, error) {
+	vars := make(map[string]interface{})
+	if input.First > 0 {
+		vars["first"] = input.First
+	} else {
+		vars["first"] = 50
+	}
+	if input.After != "" {
+		vars["after"] = input.After
+	}
+
+	var result struct {
+		ComponentVulnCustomFieldDefinitions struct {
+			Nodes []struct {
+				ID             string    `json:"id"`
+				DisplayName    string    `json:"displayName"`
+				FieldType      string    `json:"fieldType"`
+				InternalName   string    `json:"internalName"`
+				MinValue       *int      `json:"minValue"`
+				MaxValue       *int      `json:"maxValue"`
+				OrganizationID string    `json:"organizationId"`
+				CreatedAt      time.Time `json:"createdAt"`
+				UpdatedAt      time.Time `json:"updatedAt"`
+			} `json:"nodes"`
+			TotalCount int `json:"totalCount"`
+			PageInfo   struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"componentVulnCustomFieldDefinitions"`
+	}
+
+	if err := c.gql.Execute(ctx, graphql.ComponentVulnCustomFieldDefinitionsQuery, vars, &result); err != nil {
+		return nil, err
+	}
+
+	definitions := make([]ComponentVulnCustomFieldDefinition, len(result.ComponentVulnCustomFieldDefinitions.Nodes))
+	for i, node := range result.ComponentVulnCustomFieldDefinitions.Nodes {
+		definitions[i] = ComponentVulnCustomFieldDefinition{
+			ID:             node.ID,
+			DisplayName:    node.DisplayName,
+			FieldType:      node.FieldType,
+			InternalName:   node.InternalName,
+			MinValue:       node.MinValue,
+			MaxValue:       node.MaxValue,
+			OrganizationID: node.OrganizationID,
+			CreatedAt:      node.CreatedAt,
+			UpdatedAt:      node.UpdatedAt,
+		}
+	}
+
+	return &ComponentVulnCustomFieldDefinitionsResult{
+		Definitions: definitions,
+		TotalCount:  result.ComponentVulnCustomFieldDefinitions.TotalCount,
+		HasNextPage: result.ComponentVulnCustomFieldDefinitions.PageInfo.HasNextPage,
+		EndCursor:   result.ComponentVulnCustomFieldDefinitions.PageInfo.EndCursor,
 	}, nil
 }
 
@@ -604,6 +682,8 @@ func mapComponentVulnCustomFields(fields []graphQLComponentVulnCustomField) []Co
 				MinValue:       field.ComponentVulnCustomFieldDefinition.MinValue,
 				MaxValue:       field.ComponentVulnCustomFieldDefinition.MaxValue,
 				OrganizationID: field.ComponentVulnCustomFieldDefinition.OrganizationID,
+				CreatedAt:      field.ComponentVulnCustomFieldDefinition.CreatedAt,
+				UpdatedAt:      field.ComponentVulnCustomFieldDefinition.UpdatedAt,
 			}
 		}
 	}

--- a/internal/api/vulnerabilities_test.go
+++ b/internal/api/vulnerabilities_test.go
@@ -208,6 +208,61 @@ func TestListVersionVulns_MapsCustomFieldAttributes(t *testing.T) {
 	}
 }
 
+func TestListComponentVulnCustomFieldDefinitions_MapsDefinitions(t *testing.T) {
+	gql := &fakeGraphQLExecutor{
+		pages: []string{
+			`{
+				"componentVulnCustomFieldDefinitions": {
+					"nodes": [
+						{
+							"id": "field-def-1",
+							"displayName": "CRM age",
+							"fieldType": "RANGE",
+							"internalName": "crm_age",
+							"minValue": 0,
+							"maxValue": 14,
+							"organizationId": "org-1",
+							"createdAt": "2026-04-17T00:00:00Z",
+							"updatedAt": "2026-04-18T00:00:00Z"
+						}
+					],
+					"totalCount": 3,
+					"pageInfo": {
+						"hasNextPage": true,
+						"endCursor": "field-cursor-2"
+					}
+				}
+			}`,
+		},
+	}
+	client := &Client{gql: gql}
+
+	result, err := client.ListComponentVulnCustomFieldDefinitions(context.Background(), ListComponentVulnCustomFieldDefinitionsInput{
+		First: 2,
+		After: "field-cursor-1",
+	})
+	if err != nil {
+		t.Fatalf("ListComponentVulnCustomFieldDefinitions returned error: %v", err)
+	}
+
+	if gql.requests[0]["first"] != 2 || gql.requests[0]["after"] != "field-cursor-1" {
+		t.Fatalf("unexpected GraphQL variables: %#v", gql.requests[0])
+	}
+	if len(result.Definitions) != 1 {
+		t.Fatalf("len(Definitions) = %d, want 1", len(result.Definitions))
+	}
+	definition := result.Definitions[0]
+	if definition.ID != "field-def-1" || definition.DisplayName != "CRM age" || definition.InternalName != "crm_age" {
+		t.Fatalf("unexpected definition: %#v", definition)
+	}
+	if definition.MinValue == nil || *definition.MinValue != 0 || definition.MaxValue == nil || *definition.MaxValue != 14 {
+		t.Fatalf("unexpected range values: min=%#v max=%#v", definition.MinValue, definition.MaxValue)
+	}
+	if result.TotalCount != 3 || !result.HasNextPage || result.EndCursor != "field-cursor-2" {
+		t.Fatalf("unexpected pagination: %#v", result)
+	}
+}
+
 func TestListComponentVulns_PassesComponentIDs(t *testing.T) {
 	gql := &fakeGraphQLExecutor{
 		pages: []string{

--- a/internal/graphql/queries.go
+++ b/internal/graphql/queries.go
@@ -1303,6 +1303,30 @@ const (
 		}
 	`
 
+	// ComponentVulnCustomFieldDefinitionsQuery fetches custom field definitions for component vulnerabilities.
+	ComponentVulnCustomFieldDefinitionsQuery = `
+		query ComponentVulnCustomFieldDefinitions($first: Int, $after: String) {
+			componentVulnCustomFieldDefinitions(first: $first, after: $after) {
+				nodes {
+					id
+					displayName
+					fieldType
+					internalName
+					minValue
+					maxValue
+					organizationId
+					createdAt
+					updatedAt
+				}
+				totalCount
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	`
+
 	// VexStatusesQuery fetches all VEX statuses
 	VexStatusesQuery = `
 		query GetVexStatuses {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -40,6 +40,7 @@ type lynkClient interface {
 	UpdateComponentSupplier(ctx context.Context, input api.UpdateComponentSupplierInput) (*api.UpdateComponentSupplierResult, error)
 	ListVersionVulns(ctx context.Context, input api.ListVersionVulnsInput) (*api.ComponentVulnsResult, error)
 	GetVuln(ctx context.Context, id, vulnID string) (*api.Vuln, error)
+	ListComponentVulnCustomFieldDefinitions(ctx context.Context, input api.ListComponentVulnCustomFieldDefinitionsInput) (*api.ComponentVulnCustomFieldDefinitionsResult, error)
 	GetVexStatuses(ctx context.Context) ([]api.VexStatus, error)
 	GetVexJustifications(ctx context.Context) ([]api.VexJustification, error)
 	UpdateComponentVex(ctx context.Context, input api.UpdateComponentVexInput) (*api.UpdateComponentVexResult, error)
@@ -311,6 +312,12 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(mcp.NewTool("list_vex_justifications",
 		mcp.WithDescription("List VEX justifications with UUIDs for CVE triage"),
 	), s.handleListVexJustifications)
+
+	s.mcp.AddTool(mcp.NewTool("list_component_vuln_custom_field_definitions",
+		mcp.WithDescription("List component vulnerability custom field definitions with UUIDs for VEX updates"),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (default: 50)")),
+		mcp.WithString("after", mcp.Description("Cursor for the next page")),
+	), s.handleListComponentVulnCustomFieldDefinitions)
 
 	s.mcp.AddTool(mcp.NewTool("update_component_vex",
 		mcp.WithDescription("Destructively update VEX data for a component vulnerability. Requires confirm=true. Only pass fields that should change. Status and justification may be supplied by UUID or by name."),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1013,6 +1013,26 @@ func (s *Server) handleListVexJustifications(ctx context.Context, request mcp.Ca
 	})
 }
 
+func (s *Server) handleListComponentVulnCustomFieldDefinitions(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := toolArguments(request)
+	input := api.ListComponentVulnCustomFieldDefinitionsInput{
+		First: getIntParam(args, "limit", 0),
+		After: stringParam(args, "after"),
+	}
+
+	result, err := s.client.ListComponentVulnCustomFieldDefinitions(ctx, input)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list component vulnerability custom field definitions: %v", err)), nil
+	}
+
+	return formatResult(map[string]interface{}{
+		"componentVulnCustomFieldDefinitions": formatComponentVulnCustomFieldDefinitions(result.Definitions),
+		"totalCount":                          result.TotalCount,
+		"hasMore":                             result.HasNextPage,
+		"endCursor":                           result.EndCursor,
+	})
+}
+
 func (s *Server) handleUpdateComponentVex(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := toolArguments(request)
 	if !confirmed(args) {
@@ -3256,6 +3276,24 @@ func formatComponentVulnCustomFields(customFields []api.ComponentVulnCustomField
 			}
 		}
 		result[i] = item
+	}
+	return result
+}
+
+func formatComponentVulnCustomFieldDefinitions(definitions []api.ComponentVulnCustomFieldDefinition) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(definitions))
+	for i, definition := range definitions {
+		result[i] = map[string]interface{}{
+			"id":             definition.ID,
+			"displayName":    definition.DisplayName,
+			"fieldType":      definition.FieldType,
+			"internalName":   definition.InternalName,
+			"minValue":       intPointerValue(definition.MinValue),
+			"maxValue":       intPointerValue(definition.MaxValue),
+			"organizationId": definition.OrganizationID,
+			"createdAt":      definition.CreatedAt,
+			"updatedAt":      definition.UpdatedAt,
+		}
 	}
 	return result
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -32,6 +32,7 @@ type fakeLynkClient struct {
 	listVersionVulnsInput       api.ListVersionVulnsInput
 	listVersionVulnsInputs      []api.ListVersionVulnsInput
 	listVersionVulnsResults     map[string]*api.ComponentVulnsResult
+	listCustomFieldDefsInput    api.ListComponentVulnCustomFieldDefinitionsInput
 	listComponentVulnsInput     api.ListComponentVulnsInput
 	listVersionsInput           api.ListVersionsInput
 	searchVersionsInput         api.VersionSearchInput
@@ -39,6 +40,29 @@ type fakeLynkClient struct {
 	downloadSBOMInput           api.DownloadSBOMInput
 	bulkUpdateComponentVexInput api.BulkUpdateComponentVexInput
 	ticketingStatusInput        api.TicketingStatusInput
+}
+
+func (f *fakeLynkClient) ListComponentVulnCustomFieldDefinitions(ctx context.Context, input api.ListComponentVulnCustomFieldDefinitionsInput) (*api.ComponentVulnCustomFieldDefinitionsResult, error) {
+	f.listCustomFieldDefsInput = input
+	maxValue := 30
+	return &api.ComponentVulnCustomFieldDefinitionsResult{
+		Definitions: []api.ComponentVulnCustomFieldDefinition{
+			{
+				ID:             "field-def-1",
+				DisplayName:    "CRM age",
+				FieldType:      "RANGE",
+				InternalName:   "crm_age",
+				MinValue:       nil,
+				MaxValue:       &maxValue,
+				OrganizationID: "org-1",
+				CreatedAt:      time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		TotalCount:  2,
+		HasNextPage: true,
+		EndCursor:   "field-cursor-2",
+	}, nil
 }
 
 func (f *fakeLynkClient) ListLabels(ctx context.Context, input api.ListLabelsInput) (*api.LabelsResult, error) {
@@ -1240,6 +1264,41 @@ func TestFormatComponentVulns_IncludesCustomFieldAttributes(t *testing.T) {
 	definition := field["definition"].(map[string]interface{})
 	if definition["displayName"] != "CRM age" || definition["maxValue"] != 14 {
 		t.Fatalf("unexpected definition output: %#v", definition)
+	}
+}
+
+func TestHandleListComponentVulnCustomFieldDefinitions(t *testing.T) {
+	client := &fakeLynkClient{}
+	server := &Server{client: client}
+	result, err := server.handleListComponentVulnCustomFieldDefinitions(context.Background(), mcpg.CallToolRequest{
+		Params: mcpg.CallToolParams{
+			Arguments: map[string]interface{}{
+				"limit": 2,
+				"after": "field-cursor-1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleListComponentVulnCustomFieldDefinitions returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListComponentVulnCustomFieldDefinitions returned tool error: %#v", result.Content)
+	}
+	if client.listCustomFieldDefsInput.First != 2 || client.listCustomFieldDefsInput.After != "field-cursor-1" {
+		t.Fatalf("input = %#v, want limit 2 after field-cursor-1", client.listCustomFieldDefsInput)
+	}
+
+	output := toolResultMap(t, result)
+	if output["totalCount"] != float64(2) || output["hasMore"] != true || output["endCursor"] != "field-cursor-2" {
+		t.Fatalf("unexpected pagination output: %#v", output)
+	}
+	definitions := output["componentVulnCustomFieldDefinitions"].([]interface{})
+	definition := definitions[0].(map[string]interface{})
+	if definition["id"] != "field-def-1" || definition["displayName"] != "CRM age" || definition["internalName"] != "crm_age" {
+		t.Fatalf("unexpected definition output: %#v", definition)
+	}
+	if definition["minValue"] != nil || definition["maxValue"] != float64(30) {
+		t.Fatalf("unexpected range output: %#v", definition)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a direct GraphQL/API lookup for component vulnerability custom field definitions
- expose the lookup as the read-only MCP tool `list_component_vuln_custom_field_definitions`
- include pagination metadata and tests for API mapping plus MCP output

## Validation
- `go test ./...`
- `make test`